### PR TITLE
feat: RabbitMQ resilience improvements + Data Relay error interceptor

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -149,3 +149,12 @@ CALLBACK_ALLOWED_DOMAIN=
 # Callback Authentication (Optional - if not set, callbacks work without auth)
 # Used for Bearer Token authentication when calling webhook callback URLs
 CALLBACK_AUTH_TOKEN=
+
+# Data Relay - Error Interceptor
+# Sends callback failure errors to Data Relay for monitoring and alerting
+DATA_RELAY_ENABLED=false
+DATA_RELAY_BASE_URL=https://your-data-relay-service.com
+DATA_RELAY_API_KEY=your-data-relay-api-key
+DATA_RELAY_TIMEOUT=10
+DATA_RELAY_SOURCE=eai-agent-gateway
+DATA_RELAY_FLOW_NAME=wetalkie_callback

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -255,7 +255,7 @@ func setDefaults() {
 	viper.SetDefault("RABBITMQ_USER_MESSAGES_QUEUE", "user_messages")
 	viper.SetDefault("RABBITMQ_AGENT_MESSAGES_QUEUE", "agent_messages")
 	viper.SetDefault("RABBITMQ_DLX_EXCHANGE", "eai_gateway_dlx")
-	viper.SetDefault("RABBITMQ_MAX_RETRIES", 3)
+	viper.SetDefault("RABBITMQ_MAX_RETRIES", -1) // -1 = infinite retries with exponential backoff
 	viper.SetDefault("RABBITMQ_RETRY_DELAY", 30)
 	viper.SetDefault("RABBITMQ_MESSAGE_TIMEOUT", "2000s") // 33+ minutes to allow Google API calls
 	viper.SetDefault("CELERY_SOFT_TIME_LIMIT", 90)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -44,6 +44,9 @@ type Config struct {
 
 	// Callback
 	Callback CallbackConfig `mapstructure:",squash"`
+
+	// Data Relay
+	DataRelay DataRelayConfig `mapstructure:",squash"`
 }
 
 type ServerConfig struct {
@@ -210,6 +213,15 @@ type CallbackConfig struct {
 	AuthToken     string `mapstructure:"CALLBACK_AUTH_TOKEN"`
 }
 
+type DataRelayConfig struct {
+	Enabled  bool   `mapstructure:"DATA_RELAY_ENABLED"`
+	BaseURL  string `mapstructure:"DATA_RELAY_BASE_URL"`
+	APIKey   string `mapstructure:"DATA_RELAY_API_KEY"`
+	Timeout  int    `mapstructure:"DATA_RELAY_TIMEOUT"`
+	Source   string `mapstructure:"DATA_RELAY_SOURCE"`
+	FlowName string `mapstructure:"DATA_RELAY_FLOW_NAME"`
+}
+
 // Load loads configuration from environment variables and files
 func Load() (*Config, error) {
 	viper.AutomaticEnv()
@@ -361,6 +373,12 @@ func setDefaults() {
 	viper.SetDefault("CALLBACK_HMAC_SECRET", "")
 	viper.SetDefault("CALLBACK_REQUIRE_HTTPS", true)
 	viper.SetDefault("CALLBACK_ALLOWED_DOMAIN", "") // Empty = allow all
+
+	// Data Relay
+	viper.SetDefault("DATA_RELAY_ENABLED", false)
+	viper.SetDefault("DATA_RELAY_TIMEOUT", 10) // 10 seconds
+	viper.SetDefault("DATA_RELAY_SOURCE", "eai-agent-gateway")
+	viper.SetDefault("DATA_RELAY_FLOW_NAME", "wetalkie_callback")
 }
 
 func validateRequired(config *Config) error {
@@ -528,6 +546,14 @@ func bindEnvironmentVariables() {
 	_ = viper.BindEnv("CALLBACK_REQUIRE_HTTPS")
 	_ = viper.BindEnv("CALLBACK_ALLOWED_DOMAIN")
 	_ = viper.BindEnv("CALLBACK_AUTH_TOKEN")
+
+	// Data Relay
+	_ = viper.BindEnv("DATA_RELAY_ENABLED")
+	_ = viper.BindEnv("DATA_RELAY_BASE_URL")
+	_ = viper.BindEnv("DATA_RELAY_API_KEY")
+	_ = viper.BindEnv("DATA_RELAY_TIMEOUT")
+	_ = viper.BindEnv("DATA_RELAY_SOURCE")
+	_ = viper.BindEnv("DATA_RELAY_FLOW_NAME")
 }
 
 // GetLogLevel returns the logrus log level from config

--- a/internal/handlers/workers/message_handlers.go
+++ b/internal/handlers/workers/message_handlers.go
@@ -271,7 +271,7 @@ func CreateUserMessageHandler(deps *MessageHandlerDependencies) func(context.Con
 			callbackURL, err := deps.RedisService.GetCallbackURL(ctx, queueMsg.ID)
 			if err == nil && callbackURL != "" {
 				// Execute callback asynchronously to avoid blocking worker
-				go executeCallback(context.Background(), deps, queueMsg.ID, callbackURL, response, logger)
+				go executeCallback(context.Background(), deps, queueMsg.ID, queueMsg.UserNumber, callbackURL, response, logger)
 			}
 		}
 
@@ -1241,10 +1241,11 @@ func classifyTranscriptionError(err error) string {
 }
 
 // executeCallback handles the callback execution asynchronously
-func executeCallback(ctx context.Context, deps *MessageHandlerDependencies, messageID string, callbackURL string, response string, logger *logrus.Entry) {
+func executeCallback(ctx context.Context, deps *MessageHandlerDependencies, messageID string, userNumber string, callbackURL string, response string, logger *logrus.Entry) {
 	callbackLogger := logger.WithFields(logrus.Fields{
 		"callback_url": callbackURL,
 		"message_id":   messageID,
+		"user_number":  userNumber,
 	})
 
 	callbackLogger.Info("Executing callback for completed task")
@@ -1267,7 +1268,7 @@ func executeCallback(ctx context.Context, deps *MessageHandlerDependencies, mess
 	}
 
 	// Execute the callback with retry logic
-	if err := deps.CallbackService.ExecuteCallback(ctx, callbackURL, payload); err != nil {
+	if err := deps.CallbackService.ExecuteCallback(ctx, callbackURL, payload, userNumber); err != nil {
 		callbackLogger.WithError(err).Error("Failed to execute callback after all retries")
 		// Store callback failure for debugging
 		errorKey := "callback:error:" + messageID

--- a/internal/handlers/workers/message_handlers.go
+++ b/internal/handlers/workers/message_handlers.go
@@ -514,9 +514,9 @@ func processUserMessage(ctx context.Context, msg *models.QueueMessage, deps *Mes
 		}
 
 		logger.WithFields(logrus.Fields{
-			"error":              err.Error(),
-			"response_length":    len(cleanedResponse),
-			"response_preview":   cleanedResponse[:previewLen],
+			"error":            err.Error(),
+			"response_length":  len(cleanedResponse),
+			"response_preview": cleanedResponse[:previewLen],
 		}).Warn("Response is not valid JSON, treating as plain text error message")
 
 		// Create a simple message structure with the error text

--- a/internal/models/message.go
+++ b/internal/models/message.go
@@ -147,6 +147,7 @@ type CallbackPayload struct {
 type CallbackInfo struct {
 	URL         string    `json:"url"`
 	MessageID   string    `json:"message_id"`
+	UserNumber  string    `json:"user_number"` // WhatsApp number for error tracking
 	RetryCount  int       `json:"retry_count"`
 	LastAttempt time.Time `json:"last_attempt,omitempty"`
 	CreatedAt   time.Time `json:"created_at"`

--- a/internal/services/callback_service.go
+++ b/internal/services/callback_service.go
@@ -288,9 +288,9 @@ func generateHMACSignature(payload []byte, secret string) string {
 // This runs asynchronously and doesn't block the callback flow
 func (s *CallbackService) sendErrorInterceptor(ctx context.Context, callbackURL string, payload models.CallbackPayload, userNumber string, callbackErr error) {
 	logger := s.logger.WithFields(logrus.Fields{
-		"callback_url":  callbackURL,
-		"message_id":    payload.MessageID,
-		"user_number":   userNumber,
+		"callback_url":   callbackURL,
+		"message_id":     payload.MessageID,
+		"user_number":    userNumber,
 		"callback_error": callbackErr.Error(),
 	})
 

--- a/internal/services/data_relay_service.go
+++ b/internal/services/data_relay_service.go
@@ -1,0 +1,127 @@
+package services
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/prefeitura-rio/app-eai-agent-gateway/internal/config"
+)
+
+// DataRelayService handles communication with the Data Relay API
+type DataRelayService struct {
+	logger     *logrus.Logger
+	config     *config.DataRelayConfig
+	httpClient *http.Client
+}
+
+// ErrorInterceptorPayload represents the payload sent to Data Relay error interceptor
+type ErrorInterceptorPayload struct {
+	CustomerWhatsappNumber string `json:"customer_whatsapp_number"`
+	Source                 string `json:"source"`
+	FlowName               string `json:"flowname"`
+	APIEndpoint            string `json:"api_endpoint"`
+	InputBody              string `json:"input_body"`
+	HTTPStatusCode         int    `json:"http_status_code"`
+	ErrorResponse          string `json:"error_response"`
+}
+
+// NewDataRelayService creates a new Data Relay service
+func NewDataRelayService(logger *logrus.Logger, cfg *config.DataRelayConfig) *DataRelayService {
+	return &DataRelayService{
+		logger: logger,
+		config: cfg,
+		httpClient: &http.Client{
+			Timeout: time.Duration(cfg.Timeout) * time.Second,
+			Transport: &http.Transport{
+				MaxIdleConns:        10,
+				MaxIdleConnsPerHost: 5,
+				IdleConnTimeout:     30 * time.Second,
+			},
+		},
+	}
+}
+
+// SendErrorInterceptor sends callback error details to Data Relay
+// This is a fire-and-forget operation - errors are logged but not propagated
+func (s *DataRelayService) SendErrorInterceptor(ctx context.Context, payload ErrorInterceptorPayload) error {
+	logger := s.logger.WithFields(logrus.Fields{
+		"customer_number": payload.CustomerWhatsappNumber,
+		"api_endpoint":    payload.APIEndpoint,
+		"http_status":     payload.HTTPStatusCode,
+		"source":          payload.Source,
+		"flowname":        payload.FlowName,
+	})
+
+	// Validate configuration
+	if s.config.BaseURL == "" {
+		logger.Warn("Data Relay base URL not configured, skipping error interceptor")
+		return fmt.Errorf("data relay base URL not configured")
+	}
+
+	if s.config.APIKey == "" {
+		logger.Warn("Data Relay API key not configured, skipping error interceptor")
+		return fmt.Errorf("data relay API key not configured")
+	}
+
+	// Build endpoint URL
+	endpoint := fmt.Sprintf("%s/data/whatsapp-api-error-interceptor", s.config.BaseURL)
+
+	// Serialize payload
+	payloadBytes, err := json.Marshal(payload)
+	if err != nil {
+		logger.WithError(err).Error("Failed to serialize Data Relay error interceptor payload")
+		return fmt.Errorf("failed to serialize payload: %w", err)
+	}
+
+	// Create request
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(payloadBytes))
+	if err != nil {
+		logger.WithError(err).Error("Failed to create Data Relay request")
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	// Set headers
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Api-Key", s.config.APIKey)
+	req.Header.Set("User-Agent", "EAI-Agent-Gateway/1.0")
+
+	// Send request
+	logger.Debug("Sending error interceptor to Data Relay")
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		logger.WithError(err).Error("Failed to send error interceptor to Data Relay")
+		return fmt.Errorf("request failed: %w", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			logger.WithError(closeErr).Warn("Failed to close Data Relay response body")
+		}
+	}()
+
+	// Read response body
+	body, _ := io.ReadAll(resp.Body)
+
+	// Check response status
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		logger.WithFields(logrus.Fields{
+			"status_code":     resp.StatusCode,
+			"response_body":   string(body),
+			"response_length": len(body),
+		}).Warn("Data Relay error interceptor returned non-2xx status")
+		return fmt.Errorf("data relay returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	logger.WithFields(logrus.Fields{
+		"status_code":     resp.StatusCode,
+		"response_length": len(body),
+	}).Info("Error interceptor sent to Data Relay successfully")
+
+	return nil
+}


### PR DESCRIPTION
## Summary
This PR implements two major improvements to the worker's resilience and observability:

1. **RabbitMQ Reconnection Resilience**: Fixes the Feb 10th incident where workers silently gave up after 3 failed reconnection attempts
2. **Data Relay Error Interceptor**: Automatic error reporting to Data Relay when WeTalkie webhook callbacks fail

## 🐛 Problem Solved

### Feb 10th Incident Root Cause
On Feb 10, 2026 at ~11:45 BRT, the worker lost its RabbitMQ connection due to an EOF error. The worker:
- Attempted only 3 reconnection retries over ~8 seconds
- Gave up and stayed alive but inactive for 7 hours
- Caused 510 messages to timeout and go to DLQ
- Required manual pod deletion to recover

### Callback Error Visibility
No automated error reporting when WeTalkie webhook callbacks fail, making it difficult to monitor integration health.

## ✨ Solutions Implemented

### 1. RabbitMQ Resilience (3 commits)
- **Infinite retries with exponential backoff** (default: -1 = infinite)
- **Capped backoff**: max 60 seconds between retries
- **Process exit on critical failure**: triggers Kubernetes pod restart
- Backoff sequence: 1s, 2s, 5s, 10s, 17s, 26s, 37s, 50s, 60s (capped)...

### 2. Data Relay Error Interceptor (4 commits)
- **New DataRelayService**: HTTP client for Data Relay API
- **Automatic error reporting**: sends callback failures to `/data/whatsapp-api-error-interceptor`
- **Non-blocking**: runs asynchronously in goroutine
- **Comprehensive error details**: customer number, endpoint, payload, status, error response

## 📋 Commits

### RabbitMQ Resilience
1. `7552d8e` - Enable infinite RabbitMQ reconnection retries
2. `7c0fdb9` - Improve RabbitMQ reconnection resilience
3. `a21923a` - Fix gofmt formatting alignment

### Data Relay Integration
4. `47bf1de` - Add Data Relay error interceptor service
5. `c97e951` - Add UserNumber to CallbackInfo for error tracking
6. `02497c6` - Integrate Data Relay error interceptor in callback service
7. `54db833` - Wire Data Relay service into worker and message handlers

## 🧪 Testing

- ✅ Builds successfully (gateway + worker)
- ✅ `go vet ./...` passes
- ✅ `gofmt` formatting verified
- ✅ No breaking changes to existing functionality

## 🔧 Configuration

### RabbitMQ (automatic, no config needed)
```bash
RABBITMQ_MAX_RETRIES=-1  # Now default (was 3)
```

### Data Relay (opt-in)
```bash
DATA_RELAY_ENABLED=true
DATA_RELAY_BASE_URL=https://your-data-relay.com
DATA_RELAY_API_KEY=your-api-key
DATA_RELAY_TIMEOUT=10
DATA_RELAY_SOURCE=eai-agent-gateway
DATA_RELAY_FLOW_NAME=wetalkie_callback
```

## 🎯 Impact

### Before
- Worker silently failed after brief RabbitMQ outages
- No visibility into callback failures
- Manual intervention required for recovery

### After
- Worker persistently retries RabbitMQ connection
- Automatic pod restart if truly unrecoverable
- Real-time error reporting to Data Relay
- Proactive monitoring of WeTalkie integration health

## 📝 Notes

- Both features are backward compatible
- Data Relay is disabled by default (`DATA_RELAY_ENABLED=false`)
- RabbitMQ infinite retry can be overridden with `RABBITMQ_MAX_RETRIES=N`
- All error reporting is fire-and-forget (non-critical path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)