### PR TITLE
feat: add user last activity endpoint with two-tier caching

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -68,6 +68,7 @@ require (
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.7 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
+	github.com/lib/pq v1.12.0 // indirect
 	github.com/mailru/easyjson v0.7.6 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect

--- a/go.sum
+++ b/go.sum
@@ -117,6 +117,8 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
+github.com/lib/pq v1.12.0 h1:mC1zeiNamwKBecjHarAr26c/+d8V5w/u4J0I/yASbJo=
+github.com/lib/pq v1.12.0/go.mod h1:/p+8NSbOcwzAEI7wiMXFlgydTwcgTr3OSKMsD2BitpA=
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.7.6 h1:8yTIVnZgCoiM1TgqoeTl+LfU5Jg6/xL3QhGQnimLYnA=

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -19,15 +19,17 @@ import (
 
 // Server represents the HTTP server
 type Server struct {
-	config          *config.Config
-	logger          *logrus.Logger
-	router          *gin.Engine
-	httpServer      *http.Server
-	healthHandler   *handlers.HealthHandler
-	messageHandler  *handlers.MessageHandler
-	redisService    *services.RedisService
-	rabbitMQService *services.RabbitMQService
-	otelService     *services.OTelService // Optional OTel service
+	config              *config.Config
+	logger              *logrus.Logger
+	router              *gin.Engine
+	httpServer          *http.Server
+	healthHandler       *handlers.HealthHandler
+	messageHandler      *handlers.MessageHandler
+	userActivityHandler *handlers.UserActivityHandler
+	redisService        *services.RedisService
+	rabbitMQService     *services.RabbitMQService
+	postgresService     *services.PostgresService
+	otelService         *services.OTelService // Optional OTel service
 }
 
 // NewServer creates a new HTTP server
@@ -51,6 +53,12 @@ func NewServer(cfg *config.Config, logger *logrus.Logger, otelService *services.
 		return nil, fmt.Errorf("failed to initialize RabbitMQ service: %w", err)
 	}
 
+	// Initialize PostgreSQL service
+	postgresService, err := services.NewPostgresService(cfg, logger)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize PostgreSQL service: %w", err)
+	}
+
 	// Initialize Google Agent Engine service (for sync history updates)
 	var googleAgentService *services.GoogleAgentEngineService
 	rateLimiter := services.NewRateLimiterService(cfg, logger, redisService)
@@ -66,6 +74,7 @@ func NewServer(cfg *config.Config, logger *logrus.Logger, otelService *services.
 		router:          gin.New(),
 		redisService:    redisService,
 		rabbitMQService: rabbitMQService,
+		postgresService: postgresService,
 		otelService:     otelService,
 		healthHandler: handlers.NewHealthHandler(
 			cfg.Observability.HealthCheckTimeout,
@@ -78,6 +87,7 @@ func NewServer(cfg *config.Config, logger *logrus.Logger, otelService *services.
 			}
 			return nil
 		}()),
+		userActivityHandler: handlers.NewUserActivityHandler(logger, cfg, redisService, postgresService),
 	}
 
 	// Add Google Agent Engine to health checks if available
@@ -88,6 +98,7 @@ func NewServer(cfg *config.Config, logger *logrus.Logger, otelService *services.
 	// Add services to health checks
 	server.healthHandler.AddChecker("redis", redisService)
 	server.healthHandler.AddChecker("rabbitmq", rabbitMQService)
+	server.healthHandler.AddChecker("postgres", postgresService)
 
 	server.setupMiddleware()
 	server.setupRoutes()
@@ -191,6 +202,7 @@ func (s *Server) setupRoutes() {
 				message.POST("/webhook/update_history", s.messageHandler.HandleHistoryUpdateWebhook)
 				message.GET("/response", s.messageHandler.HandleMessageResponse)
 				message.GET("/debug/task-status", s.messageHandler.HandleDebugTaskStatus)
+				message.GET("/last-activity", s.userActivityHandler.HandleLastActivity)
 			}
 
 			// Note: Agent management endpoints removed - were Letta-specific
@@ -248,6 +260,13 @@ func (s *Server) Stop(ctx context.Context) error {
 	if s.rabbitMQService != nil {
 		if err := s.rabbitMQService.Close(); err != nil {
 			s.logger.WithError(err).Error("Failed to close RabbitMQ connection during shutdown")
+		}
+	}
+
+	// Close PostgreSQL connection
+	if s.postgresService != nil {
+		if err := s.postgresService.Close(); err != nil {
+			s.logger.WithError(err).Error("Failed to close PostgreSQL connection during shutdown")
 		}
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -47,6 +47,9 @@ type Config struct {
 
 	// Data Relay
 	DataRelay DataRelayConfig `mapstructure:",squash"`
+
+	// PostgreSQL (Agent Engine Database)
+	Postgres PostgresConfig `mapstructure:",squash"`
 }
 
 type ServerConfig struct {
@@ -221,6 +224,14 @@ type DataRelayConfig struct {
 	Timeout  int    `mapstructure:"DATA_RELAY_TIMEOUT"`
 	Source   string `mapstructure:"DATA_RELAY_SOURCE"`
 	FlowName string `mapstructure:"DATA_RELAY_FLOW_NAME"`
+}
+
+type PostgresConfig struct {
+	DSN             string        `mapstructure:"POSTGRES_DSN"`
+	MaxOpenConns    int           `mapstructure:"POSTGRES_MAX_OPEN_CONNS"`
+	MaxIdleConns    int           `mapstructure:"POSTGRES_MAX_IDLE_CONNS"`
+	ConnMaxLifetime time.Duration `mapstructure:"POSTGRES_CONN_MAX_LIFETIME"`
+	UserActivityTTL time.Duration `mapstructure:"POSTGRES_USER_ACTIVITY_TTL"`
 }
 
 // Load loads configuration from environment variables and files
@@ -555,6 +566,19 @@ func bindEnvironmentVariables() {
 	_ = viper.BindEnv("DATA_RELAY_TIMEOUT")
 	_ = viper.BindEnv("DATA_RELAY_SOURCE")
 	_ = viper.BindEnv("DATA_RELAY_FLOW_NAME")
+
+	// PostgreSQL
+	_ = viper.BindEnv("POSTGRES_DSN")
+	_ = viper.BindEnv("POSTGRES_MAX_OPEN_CONNS")
+	_ = viper.BindEnv("POSTGRES_MAX_IDLE_CONNS")
+	_ = viper.BindEnv("POSTGRES_CONN_MAX_LIFETIME")
+	_ = viper.BindEnv("POSTGRES_USER_ACTIVITY_TTL")
+
+	// Set PostgreSQL defaults
+	viper.SetDefault("POSTGRES_MAX_OPEN_CONNS", 25)
+	viper.SetDefault("POSTGRES_MAX_IDLE_CONNS", 5)
+	viper.SetDefault("POSTGRES_CONN_MAX_LIFETIME", 5*time.Minute)
+	viper.SetDefault("POSTGRES_USER_ACTIVITY_TTL", 24*time.Hour)
 }
 
 // GetLogLevel returns the logrus log level from config

--- a/internal/handlers/message.go
+++ b/internal/handlers/message.go
@@ -28,6 +28,8 @@ type RedisServiceInterface interface {
 	Set(ctx context.Context, key string, value string, ttl time.Duration) error
 	StoreCallbackURL(ctx context.Context, messageID string, callbackURL string, ttl time.Duration) error
 	GetCallbackURL(ctx context.Context, messageID string) (string, error)
+	SetUserLastActivity(ctx context.Context, userNumber string, timestamp time.Time, ttl time.Duration) error
+	GetUserLastActivity(ctx context.Context, userNumber string) (*time.Time, error)
 	Ping(ctx context.Context) error
 }
 

--- a/internal/handlers/user_activity.go
+++ b/internal/handlers/user_activity.go
@@ -1,0 +1,116 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/sirupsen/logrus"
+
+	"github.com/prefeitura-rio/app-eai-agent-gateway/internal/config"
+	"github.com/prefeitura-rio/app-eai-agent-gateway/internal/models"
+	"github.com/prefeitura-rio/app-eai-agent-gateway/internal/services"
+)
+
+// UserActivityHandler handles user activity tracking endpoints
+type UserActivityHandler struct {
+	logger          *logrus.Logger
+	config          *config.Config
+	redisService    RedisServiceInterface
+	postgresService *services.PostgresService
+}
+
+// NewUserActivityHandler creates a new user activity handler
+func NewUserActivityHandler(
+	logger *logrus.Logger,
+	config *config.Config,
+	redisService RedisServiceInterface,
+	postgresService *services.PostgresService,
+) *UserActivityHandler {
+	return &UserActivityHandler{
+		logger:          logger,
+		config:          config,
+		redisService:    redisService,
+		postgresService: postgresService,
+	}
+}
+
+// HandleLastActivity retrieves the timestamp of user's last message
+//
+//	@Summary		Get user's last message timestamp
+//	@Description	Returns the timestamp when the user last sent a message (cached in Redis, fallback to PostgreSQL)
+//	@Tags			User Activity
+//	@Produce		json
+//	@Param			user_number	query		string								true	"User phone number (thread ID)"
+//	@Success		200			{object}	models.UserLastActivityResponse		"Last activity timestamp found"
+//	@Failure		400			{object}	map[string]interface{}				"Invalid request"
+//	@Failure		404			{object}	map[string]interface{}				"No message history found"
+//	@Failure		500			{object}	map[string]interface{}				"Internal server error"
+//	@Router			/api/v1/message/last-activity [get]
+func (h *UserActivityHandler) HandleLastActivity(c *gin.Context) {
+	userNumber := c.Query("user_number")
+	if userNumber == "" {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error":   "Missing parameter",
+			"message": "user_number query parameter is required",
+		})
+		return
+	}
+
+	logger := h.logger.WithFields(logrus.Fields{
+		"user_number": userNumber,
+		"request_id":  c.GetString("request_id"),
+	})
+
+	logger.Debug("Handling user last activity request")
+
+	ctx, cancel := context.WithTimeout(c.Request.Context(), 5*time.Second)
+	defer cancel()
+
+	// Try cache first
+	timestamp, err := h.redisService.GetUserLastActivity(ctx, userNumber)
+	cached := true
+
+	// On cache miss, query PostgreSQL
+	if err != nil || timestamp == nil {
+		cached = false
+		logger.Debug("Cache miss, querying PostgreSQL for last activity")
+
+		timestamp, err = h.postgresService.GetLastMessageTimestamp(ctx, userNumber)
+		if err != nil {
+			logger.WithError(err).Warn("Failed to get last message timestamp from PostgreSQL")
+			c.JSON(http.StatusNotFound, gin.H{
+				"error":   "No message history found",
+				"message": "No messages found for the provided user number",
+			})
+			return
+		}
+
+		// Store in cache for future requests
+		ttl := h.config.Postgres.UserActivityTTL
+		if cacheErr := h.redisService.SetUserLastActivity(ctx, userNumber, *timestamp, ttl); cacheErr != nil {
+			logger.WithError(cacheErr).Warn("Failed to cache user last activity timestamp")
+			// Don't fail the request for cache errors
+		} else {
+			logger.WithField("ttl", ttl).Debug("Cached user last activity timestamp")
+		}
+	} else {
+		logger.Debug("Cache hit for user last activity")
+	}
+
+	ttlSeconds := int(h.config.Postgres.UserActivityTTL.Seconds())
+
+	logger.WithFields(logrus.Fields{
+		"timestamp":   timestamp,
+		"cached":      cached,
+		"ttl_seconds": ttlSeconds,
+	}).Info("Returning user last activity")
+
+	c.JSON(http.StatusOK, models.UserLastActivityResponse{
+		UserNumber:           userNumber,
+		LastMessageTimestamp: timestamp.Format(time.RFC3339),
+		Cached:               cached,
+		TTLSeconds:           ttlSeconds,
+	})
+}

--- a/internal/models/message.go
+++ b/internal/models/message.go
@@ -152,3 +152,11 @@ type CallbackInfo struct {
 	LastAttempt time.Time `json:"last_attempt,omitempty"`
 	CreatedAt   time.Time `json:"created_at"`
 }
+
+// UserLastActivityResponse represents the response for user last activity endpoint
+type UserLastActivityResponse struct {
+	UserNumber           string `json:"user_number" example:"5521999999999"`
+	LastMessageTimestamp string `json:"last_message_timestamp" example:"2026-03-24T14:30:00Z"`
+	Cached               bool   `json:"cached" example:"true"`
+	TTLSeconds           int    `json:"ttl_seconds" example:"86400"`
+}

--- a/internal/services/postgres_service.go
+++ b/internal/services/postgres_service.go
@@ -1,0 +1,161 @@
+package services
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	_ "github.com/lib/pq" // PostgreSQL driver
+	"github.com/sirupsen/logrus"
+
+	"github.com/prefeitura-rio/app-eai-agent-gateway/internal/config"
+)
+
+// PostgresService handles PostgreSQL operations for agent engine database
+type PostgresService struct {
+	db     *sql.DB
+	logger *logrus.Logger
+	config *config.Config
+}
+
+// NewPostgresService creates a new PostgreSQL service with connection pooling
+func NewPostgresService(cfg *config.Config, logger *logrus.Logger) (*PostgresService, error) {
+	// Open connection with PostgreSQL driver
+	db, err := sql.Open("postgres", cfg.Postgres.DSN)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open postgres connection: %w", err)
+	}
+
+	// Configure connection pool
+	db.SetMaxOpenConns(cfg.Postgres.MaxOpenConns)
+	db.SetMaxIdleConns(cfg.Postgres.MaxIdleConns)
+	db.SetConnMaxLifetime(cfg.Postgres.ConnMaxLifetime)
+
+	// Test connection with retry logic
+	const maxRetries = 5
+	const baseBackoff = 2 * time.Second
+
+	var lastErr error
+	for attempt := 1; attempt <= maxRetries; attempt++ {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		err := db.PingContext(ctx)
+		cancel()
+
+		if err == nil {
+			break
+		}
+
+		lastErr = err
+
+		if attempt == maxRetries {
+			db.Close()
+			return nil, fmt.Errorf("failed to connect to postgres after %d attempts: %w", maxRetries, lastErr)
+		}
+
+		backoff := time.Duration(attempt) * baseBackoff
+		logger.WithFields(logrus.Fields{
+			"attempt":     attempt,
+			"max_retries": maxRetries,
+			"backoff":     backoff,
+			"error":       err,
+		}).Warn("Postgres connection attempt failed, retrying...")
+
+		time.Sleep(backoff)
+	}
+
+	logger.WithFields(logrus.Fields{
+		"max_open_conns": cfg.Postgres.MaxOpenConns,
+		"max_idle_conns": cfg.Postgres.MaxIdleConns,
+		"max_lifetime":   cfg.Postgres.ConnMaxLifetime,
+	}).Info("Postgres service initialized successfully")
+
+	return &PostgresService{
+		db:     db,
+		logger: logger,
+		config: cfg,
+	}, nil
+}
+
+// GetLastMessageTimestamp retrieves the timestamp of the most recent message from a user
+// Uses parameterized query ($1 placeholder) to prevent SQL injection
+func (p *PostgresService) GetLastMessageTimestamp(ctx context.Context, threadID string) (*time.Time, error) {
+	// Use $1 placeholder for parameterized query - prevents SQL injection
+	query := `
+		SELECT c.checkpoint_id
+		FROM checkpoints c
+		WHERE c.thread_id = $1
+		  AND c.checkpoint_ns = ''
+		ORDER BY c.checkpoint_id DESC
+		LIMIT 1
+	`
+
+	var checkpointID int64
+
+	// QueryRowContext with parameterized query - threadID is safely escaped by driver
+	err := p.db.QueryRowContext(ctx, query, threadID).Scan(&checkpointID)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, fmt.Errorf("no messages found for thread: %s", threadID)
+		}
+		p.logger.WithError(err).WithField("thread_id", threadID).Error("Failed to query last message timestamp")
+		return nil, fmt.Errorf("postgres query error: %w", err)
+	}
+
+	// Convert checkpoint_id to timestamp
+	// checkpoint_id is a bigint that represents nanoseconds since epoch in LangGraph
+	timestamp := time.Unix(0, checkpointID)
+
+	p.logger.WithFields(logrus.Fields{
+		"thread_id":     threadID,
+		"checkpoint_id": checkpointID,
+		"timestamp":     timestamp,
+	}).Debug("Retrieved last message timestamp from postgres")
+
+	return &timestamp, nil
+}
+
+// GetThreadMessageCount returns the total number of checkpoints for a thread
+// Uses parameterized query ($1 placeholder) to prevent SQL injection
+func (p *PostgresService) GetThreadMessageCount(ctx context.Context, threadID string) (int64, error) {
+	query := `
+		SELECT COUNT(*)
+		FROM checkpoints
+		WHERE thread_id = $1
+		  AND checkpoint_ns = ''
+	`
+
+	var count int64
+
+	err := p.db.QueryRowContext(ctx, query, threadID).Scan(&count)
+	if err != nil {
+		p.logger.WithError(err).WithField("thread_id", threadID).Error("Failed to count thread messages")
+		return 0, fmt.Errorf("postgres query error: %w", err)
+	}
+
+	return count, nil
+}
+
+// HealthCheck tests the PostgreSQL connection
+func (p *PostgresService) HealthCheck(ctx context.Context) error {
+	if err := p.db.PingContext(ctx); err != nil {
+		p.logger.WithError(err).Error("Postgres ping failed")
+		return fmt.Errorf("postgres ping error: %w", err)
+	}
+	return nil
+}
+
+// Close closes the PostgreSQL connection
+func (p *PostgresService) Close() error {
+	if err := p.db.Close(); err != nil {
+		p.logger.WithError(err).Error("Failed to close Postgres connection")
+		return fmt.Errorf("postgres close error: %w", err)
+	}
+	p.logger.Info("Postgres connection closed")
+	return nil
+}
+
+// GetStats returns PostgreSQL connection pool statistics
+func (p *PostgresService) GetStats() sql.DBStats {
+	return p.db.Stats()
+}

--- a/internal/services/redis_service.go
+++ b/internal/services/redis_service.go
@@ -112,6 +112,11 @@ type CacheInterface interface {
 	GetCallbackURL(ctx context.Context, messageID string) (string, error)
 	DeleteCallbackURL(ctx context.Context, messageID string) error
 
+	// User activity tracking
+	SetUserLastActivity(ctx context.Context, userNumber string, timestamp time.Time, ttl time.Duration) error
+	GetUserLastActivity(ctx context.Context, userNumber string) (*time.Time, error)
+	DeleteUserLastActivity(ctx context.Context, userNumber string) error
+
 	// Health check
 	Ping(ctx context.Context) error
 	Close() error
@@ -413,6 +418,36 @@ func (r *RedisService) ResetMetrics() {
 // GetStats returns Redis connection pool statistics
 func (r *RedisService) GetStats() *redis.PoolStats {
 	return r.client.PoolStats()
+}
+
+// SetUserLastActivity stores the timestamp of user's last message activity
+func (r *RedisService) SetUserLastActivity(ctx context.Context, userNumber string, timestamp time.Time, ttl time.Duration) error {
+	key := fmt.Sprintf("user:last_activity:%s", userNumber)
+	// Store as RFC3339 string for readability
+	return r.SetValue(ctx, key, timestamp.Format(time.RFC3339), ttl)
+}
+
+// GetUserLastActivity retrieves the cached timestamp of user's last message activity
+func (r *RedisService) GetUserLastActivity(ctx context.Context, userNumber string) (*time.Time, error) {
+	key := fmt.Sprintf("user:last_activity:%s", userNumber)
+	timestampStr, err := r.Get(ctx, key)
+	if err != nil {
+		return nil, err
+	}
+
+	timestamp, err := time.Parse(time.RFC3339, timestampStr)
+	if err != nil {
+		r.logger.WithError(err).WithField("timestamp_str", timestampStr).Error("Failed to parse timestamp")
+		return nil, fmt.Errorf("invalid timestamp format: %w", err)
+	}
+
+	return &timestamp, nil
+}
+
+// DeleteUserLastActivity removes cached user activity timestamp
+func (r *RedisService) DeleteUserLastActivity(ctx context.Context, userNumber string) error {
+	key := fmt.Sprintf("user:last_activity:%s", userNumber)
+	return r.Delete(ctx, key)
 }
 
 // HealthCheck implements the HealthChecker interface

--- a/internal/workers/base_worker.go
+++ b/internal/workers/base_worker.go
@@ -187,6 +187,21 @@ func (w *BaseWorker) handleMessage(ctx context.Context, delivery amqp.Delivery) 
 			procCtx.Logger.WithError(err).Error("Failed to set completed status")
 		}
 
+		// Cache user's last activity timestamp (only for user messages, not history updates)
+		if procCtx.UserNumber != "" && w.workerType == models.WorkerTypeUserMessage {
+			timestamp := time.Now()
+			ttl := w.deps.Config.Postgres.UserActivityTTL
+			if err := w.deps.RedisService.SetUserLastActivity(ctx, procCtx.UserNumber, timestamp, ttl); err != nil {
+				procCtx.Logger.WithError(err).Warn("Failed to cache user last activity timestamp")
+				// Don't fail the whole operation for cache errors
+			} else {
+				procCtx.Logger.WithFields(logrus.Fields{
+					"timestamp": timestamp,
+					"ttl":       ttl,
+				}).Debug("Cached user last activity timestamp")
+			}
+		}
+
 	} else {
 		procCtx.Logger.WithError(result.Error).Error("Message processing failed")
 

--- a/internal/workers/interfaces.go
+++ b/internal/workers/interfaces.go
@@ -76,6 +76,7 @@ type RedisServiceInterface interface {
 	Set(ctx context.Context, key string, value string, ttl time.Duration) error
 	SetValue(ctx context.Context, key string, value interface{}, ttl time.Duration) error
 	Delete(ctx context.Context, key string) error
+	SetUserLastActivity(ctx context.Context, userNumber string, timestamp time.Time, ttl time.Duration) error
 }
 
 // TranscribeServiceInterface defines audio transcription operations
@@ -155,6 +156,7 @@ type WorkerStatus struct {
 type ProcessingContext struct {
 	MessageID     string
 	UserID        string
+	UserNumber    string // Phone number for user activity tracking
 	AgentID       string
 	ThreadID      string
 	CorrelationID string
@@ -185,6 +187,7 @@ func NewProcessingContext(queueMessage *models.QueueMessage, logger *logrus.Logg
 	return &ProcessingContext{
 		MessageID:     queueMessage.ID,
 		UserID:        queueMessage.UserNumber,
+		UserNumber:    queueMessage.UserNumber,
 		AgentID:       queueMessage.AgentID,
 		CorrelationID: correlationID,
 		StartTime:     time.Now(),


### PR DESCRIPTION
## Summary
- Implements new endpoint `GET /api/v1/message/last-activity` to retrieve user's last message timestamp
- Two-tier caching strategy: write-through on message processing + read-through on endpoint calls
- SQL injection protection via parameterized queries
- Graceful fallback from Redis cache to PostgreSQL database

## Architecture
**Caching Strategy:**
- **Write-through**: Worker caches timestamp in Redis after successfully processing user messages
- **Read-through**: Endpoint checks Redis first, falls back to PostgreSQL on cache miss
- Cache TTL: 24 hours (configurable via `POSTGRES_USER_ACTIVITY_TTL`)

**Data Flow:**
1. User sends message → Worker processes → Caches timestamp in Redis
2. Client calls `/last-activity` → Check Redis cache → If miss, query PostgreSQL checkpoints table → Cache result

## Security
- Parameterized queries using `$1` placeholders (no SQL injection risk)
- No string concatenation in SQL statements
- Connection pooling with configurable limits

## API Endpoint
```http
GET /api/v1/message/last-activity?user_number=5521999999999
```

**Response:**
```json
{
  "user_number": "5521999999999",
  "last_message_timestamp": "2026-03-24T14:30:00Z",
  "cached": true,
  "ttl_seconds": 86400
}
```

## New Configuration Variables
```bash
# Required
POSTGRES_DSN="postgresql://user:pass@host:5432/dbname"

# Optional (with defaults)
POSTGRES_MAX_OPEN_CONNS=25
POSTGRES_MAX_IDLE_CONNS=5
POSTGRES_CONN_MAX_LIFETIME=5m
POSTGRES_USER_ACTIVITY_TTL=24h
```

## Files Changed
**New:**
- `internal/services/postgres_service.go` - PostgreSQL client with checkpoint queries
- `internal/handlers/user_activity.go` - HTTP handler for last activity endpoint

**Modified:**
- `internal/config/config.go` - PostgreSQL configuration
- `internal/services/redis_service.go` - User activity cache methods
- `internal/models/message.go` - UserLastActivityResponse model
- `internal/workers/base_worker.go` - Write-through caching
- `internal/workers/interfaces.go` - UserNumber field
- `internal/handlers/message.go` - Extended RedisServiceInterface
- `internal/api/server.go` - Service wiring and route registration
- `go.mod`/`go.sum` - Added PostgreSQL driver

## Test Plan
- [ ] Deploy to staging environment with `POSTGRES_DSN` configured
- [ ] Send test message via `/api/v1/message/webhook/user`
- [ ] Verify timestamp cached in Redis: `redis-cli GET user:last_activity:<phone>`
- [ ] Call `/api/v1/message/last-activity?user_number=<phone>` → Should return cached timestamp
- [ ] Delete cache: `redis-cli DEL user:last_activity:<phone>`
- [ ] Call endpoint again → Should return from PostgreSQL (cached=false)
- [ ] Verify PostgreSQL health check: `curl /health` → postgres should be healthy
- [ ] Test error cases: invalid user_number, non-existent user

## Dependencies
- Requires access to agent-engine PostgreSQL database
- Database connection configured via `POSTGRES_DSN` environment variable

🤖 Generated with [Claude Code](https://claude.com/claude-code)