### PR TITLE
fix: correct TTL reporting and cache update reliability for user activity

### DIFF
--- a/internal/handlers/message.go
+++ b/internal/handlers/message.go
@@ -30,6 +30,7 @@ type RedisServiceInterface interface {
 	GetCallbackURL(ctx context.Context, messageID string) (string, error)
 	SetUserLastActivity(ctx context.Context, userNumber string, timestamp time.Time, ttl time.Duration) error
 	GetUserLastActivity(ctx context.Context, userNumber string) (*time.Time, error)
+	GetUserLastActivityTTL(ctx context.Context, userNumber string) (time.Duration, error)
 	Ping(ctx context.Context) error
 }
 

--- a/internal/handlers/user_activity.go
+++ b/internal/handlers/user_activity.go
@@ -99,7 +99,21 @@ func (h *UserActivityHandler) HandleLastActivity(c *gin.Context) {
 		logger.Debug("Cache hit for user last activity")
 	}
 
+	// Default TTL is the configured value (used when the key was just written, or on fallback)
 	ttlSeconds := int(h.config.Postgres.UserActivityTTL.Seconds())
+
+	// When the value came from cache, query Redis for the actual remaining TTL so the
+	// caller can observe the key expiring in real time instead of always seeing the
+	// full configured TTL.
+	if cached {
+		remainingTTL, ttlErr := h.redisService.GetUserLastActivityTTL(ctx, userNumber)
+		if ttlErr != nil {
+			logger.WithError(ttlErr).Warn("Failed to get remaining TTL from Redis, falling back to configured TTL")
+		} else if remainingTTL >= 0 {
+			// remainingTTL == -1 means the key has no expiry; keep the configured value in that case.
+			ttlSeconds = int(remainingTTL.Seconds())
+		}
+	}
 
 	logger.WithFields(logrus.Fields{
 		"timestamp":   timestamp,

--- a/internal/services/redis_service.go
+++ b/internal/services/redis_service.go
@@ -115,6 +115,7 @@ type CacheInterface interface {
 	// User activity tracking
 	SetUserLastActivity(ctx context.Context, userNumber string, timestamp time.Time, ttl time.Duration) error
 	GetUserLastActivity(ctx context.Context, userNumber string) (*time.Time, error)
+	GetUserLastActivityTTL(ctx context.Context, userNumber string) (time.Duration, error)
 	DeleteUserLastActivity(ctx context.Context, userNumber string) error
 
 	// Health check
@@ -442,6 +443,19 @@ func (r *RedisService) GetUserLastActivity(ctx context.Context, userNumber strin
 	}
 
 	return &timestamp, nil
+}
+
+// GetUserLastActivityTTL returns the remaining TTL for a user's last activity key.
+// Returns -1 if the key exists but has no expiry, -2 if the key does not exist,
+// or a positive duration representing seconds remaining.
+func (r *RedisService) GetUserLastActivityTTL(ctx context.Context, userNumber string) (time.Duration, error) {
+	key := fmt.Sprintf("user:last_activity:%s", userNumber)
+	ttl, err := r.client.TTL(ctx, key).Result()
+	if err != nil {
+		r.logger.WithError(err).WithField("key", key).Error("Failed to get TTL from Redis")
+		return 0, fmt.Errorf("redis TTL error: %w", err)
+	}
+	return ttl, nil
 }
 
 // DeleteUserLastActivity removes cached user activity timestamp

--- a/internal/workers/base_worker.go
+++ b/internal/workers/base_worker.go
@@ -187,19 +187,35 @@ func (w *BaseWorker) handleMessage(ctx context.Context, delivery amqp.Delivery) 
 			procCtx.Logger.WithError(err).Error("Failed to set completed status")
 		}
 
-		// Cache user's last activity timestamp (only for user messages, not history updates)
+		// Cache user's last activity timestamp (only for user messages, not history updates).
+		// Use a fresh background context so that a cancelled or timed-out consumer context
+		// does not silently skip the write.
 		if procCtx.UserNumber != "" && w.workerType == models.WorkerTypeUserMessage {
 			timestamp := time.Now()
 			ttl := w.deps.Config.Postgres.UserActivityTTL
-			if err := w.deps.RedisService.SetUserLastActivity(ctx, procCtx.UserNumber, timestamp, ttl); err != nil {
+			activityCtx, activityCancel := context.WithTimeout(context.Background(), 5*time.Second)
+			procCtx.Logger.WithFields(logrus.Fields{
+				"user_number": procCtx.UserNumber,
+				"timestamp":   timestamp,
+				"ttl":         ttl,
+			}).Debug("Attempting to cache user last activity timestamp")
+			if err := w.deps.RedisService.SetUserLastActivity(activityCtx, procCtx.UserNumber, timestamp, ttl); err != nil {
 				procCtx.Logger.WithError(err).Warn("Failed to cache user last activity timestamp")
 				// Don't fail the whole operation for cache errors
 			} else {
 				procCtx.Logger.WithFields(logrus.Fields{
-					"timestamp": timestamp,
-					"ttl":       ttl,
-				}).Debug("Cached user last activity timestamp")
+					"user_number": procCtx.UserNumber,
+					"timestamp":   timestamp,
+					"ttl":         ttl,
+				}).Info("Cached user last activity timestamp")
 			}
+			activityCancel()
+		} else {
+			procCtx.Logger.WithFields(logrus.Fields{
+				"user_number":  procCtx.UserNumber,
+				"worker_type":  w.workerType,
+				"expected_type": models.WorkerTypeUserMessage,
+			}).Debug("Skipping user last activity cache update (condition not met)")
 		}
 
 	} else {


### PR DESCRIPTION
## Summary

- **Bug 1 (TTL not decreasing):** The `/api/v1/message/last-activity` endpoint was always returning the full *configured* TTL (e.g. 86400s from `POSTGRES_USER_ACTIVITY_TTL`) instead of the actual *remaining* Redis TTL. The endpoint now calls the Redis `TTL` command via a new `GetUserLastActivityTTL` method when the response comes from cache, so `ttl_seconds` in the response decreases in real time.
- **Bug 2 (Data not updating):** `SetUserLastActivity` in `base_worker.go` was called using the RabbitMQ consumer context, which is commonly already cancelled or timed-out by the time Google Agent Engine finishes (calls can take several minutes). A cancelled context causes the Redis `SET` to fail silently with no retry, so the cached timestamp never advanced. Fixed by using `context.WithTimeout(context.Background(), 5s)` for this specific write, consistent with the pattern already used for the error-path Redis writes in the same function.

## Changes

| File | Change |
|------|--------|
| `internal/services/redis_service.go` | Added `GetUserLastActivityTTL` to `CacheInterface` and `RedisService` (uses Redis `TTL` command) |
| `internal/handlers/message.go` | Added `GetUserLastActivityTTL` to `RedisServiceInterface` |
| `internal/handlers/user_activity.go` | Query remaining Redis TTL when response is cached; fall back to configured value on error or when value was just written |
| `internal/workers/base_worker.go` | Use `context.Background()` (with 5s timeout) for `SetUserLastActivity` call; promote success log from Debug to Info; add Debug log for skipped-condition branch |

## Test plan

- [ ] Send a message for a user and call `GET /api/v1/message/last-activity?user_number=<number>` immediately - `cached: false`, `ttl_seconds` ~86400
- [ ] Call again within a few seconds - `cached: true`, `ttl_seconds` should now be slightly less than 86400 (not 86400)
- [ ] Wait 60 seconds and call again - `ttl_seconds` should be ~86340, confirming real-time decrease
- [ ] Send another message and call the endpoint - `last_message_timestamp` should update to the new timestamp
- [ ] Verify log line `"Cached user last activity timestamp"` at Info level appears in staging worker logs after message processing

🤖 Generated with [Claude Code](https://claude.com/claude-code)