### PR TITLE
fix: move cache update logic to actual message handler

### DIFF
--- a/internal/handlers/workers/message_handlers.go
+++ b/internal/handlers/workers/message_handlers.go
@@ -254,6 +254,30 @@ func CreateUserMessageHandler(deps *MessageHandlerDependencies) func(context.Con
 			logger.WithError(err).Error("Failed to update task status to completed")
 		}
 
+		// Cache user's last activity timestamp (only for user messages)
+		if queueMsg.UserNumber != "" {
+			timestamp := time.Now()
+			ttl := deps.Config.Postgres.UserActivityTTL
+			activityCtx, activityCancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer activityCancel()
+
+			logger.WithFields(logrus.Fields{
+				"user_number": queueMsg.UserNumber,
+				"timestamp":   timestamp,
+				"ttl":         ttl,
+			}).Debug("Attempting to cache user last activity timestamp")
+
+			if err := deps.RedisService.SetUserLastActivity(activityCtx, queueMsg.UserNumber, timestamp, ttl); err != nil {
+				logger.WithError(err).Warn("Failed to cache user last activity timestamp")
+			} else {
+				logger.WithFields(logrus.Fields{
+					"user_number": queueMsg.UserNumber,
+					"timestamp":   timestamp,
+					"ttl":         ttl,
+				}).Info("Cached user last activity timestamp")
+			}
+		}
+
 		// Add success attributes to the main span if available
 		if deps.OTelWorkerWrapper != nil {
 			if span := trace.SpanFromContext(ctx); span.IsRecording() {


### PR DESCRIPTION
## Summary

This PR fixes the architectural issue discovered in PR #20 where cache update code was added to `base_worker.handleMessage()` but was never executed because the worker uses `CreateUserMessageHandler()` which bypasses the base worker's message handling flow entirely.

### Problem
- PR #20 added cache update logic to `base_worker.go:190-219`
- The code was never executed because workers use `CreateUserMessageHandler()` from `message_handlers.go`
- `ConsumerManager.AddConsumer()` registers the handler directly, bypassing `base_worker.handleMessage()`
- User activity cache was not being updated despite messages being processed successfully

### Solution
- Move cache update logic to `message_handlers.go:CreateUserMessageHandler()`
- Insert after task status is set to completed (line 255) but before callback execution
- Uses fresh background context to avoid timeout issues
- Logs debug and info messages for observability

### Evidence
- Logs show "User message processed successfully" for phone 5521996143632
- No "Cached user last activity" logs appeared (because code was in wrong location)
- Architecture investigation revealed handler flow: `cmd/worker/main.go:158` → `CreateUserMessageHandler()` → `message_consumer.go:249` direct handler call

## Test Plan
- [ ] Deploy to staging
- [ ] Send test message to phone number 5521996143632
- [ ] Verify "Cached user last activity timestamp" log appears
- [ ] Verify cache TTL decreases over time via `/api/v1/message/last-activity` endpoint
- [ ] Verify cache timestamp updates when new messages arrive

🤖 Generated with [Claude Code](https://claude.com/claude-code)