### PR TITLE
chore: promote staging → main

### DIFF
--- a/internal/services/message_consumer.go
+++ b/internal/services/message_consumer.go
@@ -129,9 +129,8 @@ func (r *RabbitMQService) StopConsumer(queueName string) error {
 func (c *Consumer) workerLoop(ctx context.Context, workerID int) {
 	defer c.wg.Done()
 
-	// Generate unique consumer tag to avoid conflicts between containers
 	hostname, _ := os.Hostname()
-	uniqueID := uuid.New().String()[:8] // Use first 8 chars of UUID
+	uniqueID := uuid.New().String()[:8]
 	consumerTag := fmt.Sprintf("worker_%s_%s_%d", hostname, uniqueID, workerID)
 
 	logger := c.logger.WithFields(logrus.Fields{
@@ -140,16 +139,7 @@ func (c *Consumer) workerLoop(ctx context.Context, workerID int) {
 		"consumer_tag": consumerTag,
 	})
 
-	// Start consuming for this worker
-	msgs, err := c.rabbitMQ.channel.Consume(
-		c.queueName, // queue
-		consumerTag, // consumer tag (unique across containers)
-		false,       // auto-ack
-		false,       // exclusive
-		false,       // no-local
-		false,       // no-wait
-		nil,         // arguments
-	)
+	msgs, err := c.rabbitMQ.ConsumeQueue(c.queueName, consumerTag)
 	if err != nil {
 		logger.WithError(err).Error("Failed to start consuming messages")
 		return
@@ -167,10 +157,36 @@ func (c *Consumer) workerLoop(ctx context.Context, workerID int) {
 			return
 		case msg, ok := <-msgs:
 			if !ok {
-				logger.Info("Message channel closed for worker")
-				return
+				logger.Warn("AMQP channel closed, waiting for reconnect to re-register consumer")
+				msgs = c.waitAndReRegister(ctx, consumerTag, logger)
+				if msgs == nil {
+					return
+				}
+				continue
 			}
 			c.processMessageWithRetry(ctx, msg, logger)
+		}
+	}
+}
+
+// waitAndReRegister blocks until the RabbitMQ connection is re-established and
+// successfully re-registers this consumer. Returns nil if ctx or stopChan fires.
+func (c *Consumer) waitAndReRegister(ctx context.Context, consumerTag string, logger *logrus.Entry) <-chan amqp.Delivery {
+	for {
+		reconnectedCh := c.rabbitMQ.ReconnectedCh()
+
+		msgs, err := c.rabbitMQ.ConsumeQueue(c.queueName, consumerTag)
+		if err == nil {
+			logger.Info("Consumer re-registered after reconnect")
+			return msgs
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-c.stopChan:
+			return nil
+		case <-reconnectedCh:
 		}
 	}
 }

--- a/internal/services/rabbitmq_service.go
+++ b/internal/services/rabbitmq_service.go
@@ -27,6 +27,12 @@ type RabbitMQService struct {
 	notifyChanClose chan *amqp.Error
 	notifyReconnect chan bool
 	isShutdown      bool
+
+	// Reconnect broadcast: closed and replaced on every successful reconnect.
+	// Consumer goroutines wait on the channel returned by ReconnectedCh() to
+	// know when they can re-register with the new AMQP channel.
+	reconnectedMu sync.RWMutex
+	reconnectedCh chan struct{}
 }
 
 // MessagePublisher defines the interface for publishing messages
@@ -61,6 +67,7 @@ func NewRabbitMQService(cfg *config.Config, logger *logrus.Logger) (*RabbitMQSer
 		config:          cfg,
 		logger:          logger,
 		notifyReconnect: make(chan bool),
+		reconnectedCh:   make(chan struct{}),
 	}
 
 	if err := service.connect(); err != nil {
@@ -480,6 +487,7 @@ func (r *RabbitMQService) reconnect() {
 			continue
 		}
 
+		r.broadcastReconnected()
 		r.logger.Info("Successfully reconnected to RabbitMQ")
 		return
 	}
@@ -572,4 +580,37 @@ func (r *RabbitMQService) TriggerReconnect() {
 	default:
 		// Channel is full, reconnection already in progress
 	}
+}
+
+// broadcastReconnected signals all goroutines waiting in ReconnectedCh that a
+// new AMQP connection and channel are ready. Must be called after r.mutex is
+// released so waiters can immediately call ConsumeQueue without deadlocking.
+func (r *RabbitMQService) broadcastReconnected() {
+	r.reconnectedMu.Lock()
+	old := r.reconnectedCh
+	r.reconnectedCh = make(chan struct{})
+	r.reconnectedMu.Unlock()
+	close(old)
+}
+
+// ReconnectedCh returns a channel that is closed when the next successful
+// reconnect completes. Call this before checking IsConnected to avoid missing
+// a reconnect event between the two operations.
+func (r *RabbitMQService) ReconnectedCh() <-chan struct{} {
+	r.reconnectedMu.RLock()
+	defer r.reconnectedMu.RUnlock()
+	return r.reconnectedCh
+}
+
+// ConsumeQueue registers a consumer on the current channel under a read lock,
+// returning the delivery channel. Safe to call after ReconnectedCh fires.
+func (r *RabbitMQService) ConsumeQueue(queueName, consumerTag string) (<-chan amqp.Delivery, error) {
+	r.mutex.RLock()
+	defer r.mutex.RUnlock()
+
+	if !r.isConnected {
+		return nil, fmt.Errorf("RabbitMQ not connected")
+	}
+
+	return r.channel.Consume(queueName, consumerTag, false, false, false, false, nil)
 }


### PR DESCRIPTION
Inclui fix/consumer-reconnect (PR #23) — re-register consumers após reconexão RabbitMQ.