### PR TITLE
feat(api): alinhar message_type interactive ao registry MCP

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -53,7 +53,7 @@ const docTemplate = `{
                     "200": {
                         "description": "Task debug information",
                         "schema": {
-                            "$ref": "#/definitions/models.TaskDebugInfo"
+                            "$ref": "#/definitions/github_com_prefeitura-rio_app-eai-agent-gateway_internal_models.TaskDebugInfo"
                         }
                     },
                     "400": {
@@ -103,7 +103,7 @@ const docTemplate = `{
                     "200": {
                         "description": "Last activity timestamp found",
                         "schema": {
-                            "$ref": "#/definitions/models.UserLastActivityResponse"
+                            "$ref": "#/definitions/github_com_prefeitura-rio_app-eai-agent-gateway_internal_models.UserLastActivityResponse"
                         }
                     },
                     "400": {
@@ -156,13 +156,13 @@ const docTemplate = `{
                     "200": {
                         "description": "Message completed or failed",
                         "schema": {
-                            "$ref": "#/definitions/models.MessageResponse"
+                            "$ref": "#/definitions/github_com_prefeitura-rio_app-eai-agent-gateway_internal_models.MessageResponse"
                         }
                     },
                     "202": {
                         "description": "Message still processing",
                         "schema": {
-                            "$ref": "#/definitions/models.MessageResponse"
+                            "$ref": "#/definitions/github_com_prefeitura-rio_app-eai-agent-gateway_internal_models.MessageResponse"
                         }
                     },
                     "400": {
@@ -209,7 +209,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.HistoryUpdateWebhookRequest"
+                            "$ref": "#/definitions/github_com_prefeitura-rio_app-eai-agent-gateway_internal_models.HistoryUpdateWebhookRequest"
                         }
                     }
                 ],
@@ -258,7 +258,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.UserWebhookRequest"
+                            "$ref": "#/definitions/github_com_prefeitura-rio_app-eai-agent-gateway_internal_models.UserWebhookRequest"
                         }
                     }
                 ],
@@ -266,7 +266,7 @@ const docTemplate = `{
                     "202": {
                         "description": "Message queued successfully",
                         "schema": {
-                            "$ref": "#/definitions/models.WebhookResponse"
+                            "$ref": "#/definitions/github_com_prefeitura-rio_app-eai-agent-gateway_internal_models.WebhookResponse"
                         }
                     },
                     "400": {
@@ -374,7 +374,7 @@ const docTemplate = `{
         }
     },
     "definitions": {
-        "models.HistoryMessage": {
+        "github_com_prefeitura-rio_app-eai-agent-gateway_internal_models.HistoryMessage": {
             "type": "object",
             "required": [
                 "content",
@@ -391,7 +391,7 @@ const docTemplate = `{
                 }
             }
         },
-        "models.HistoryUpdateWebhookRequest": {
+        "github_com_prefeitura-rio_app-eai-agent-gateway_internal_models.HistoryUpdateWebhookRequest": {
             "type": "object",
             "required": [
                 "messages",
@@ -402,7 +402,7 @@ const docTemplate = `{
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "#/definitions/models.HistoryMessage"
+                        "$ref": "#/definitions/github_com_prefeitura-rio_app-eai-agent-gateway_internal_models.HistoryMessage"
                     }
                 },
                 "metadata": {
@@ -419,7 +419,7 @@ const docTemplate = `{
                 }
             }
         },
-        "models.MessageResponse": {
+        "github_com_prefeitura-rio_app-eai-agent-gateway_internal_models.MessageResponse": {
             "description": "Message processing response",
             "type": "object",
             "properties": {
@@ -436,7 +436,7 @@ const docTemplate = `{
                 }
             }
         },
-        "models.TaskDebugInfo": {
+        "github_com_prefeitura-rio_app-eai-agent-gateway_internal_models.TaskDebugInfo": {
             "type": "object",
             "properties": {
                 "created_at": {
@@ -462,14 +462,14 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "status": {
-                    "$ref": "#/definitions/models.TaskStatus"
+                    "$ref": "#/definitions/github_com_prefeitura-rio_app-eai-agent-gateway_internal_models.TaskStatus"
                 },
                 "updated_at": {
                     "type": "string"
                 }
             }
         },
-        "models.TaskStatus": {
+        "github_com_prefeitura-rio_app-eai-agent-gateway_internal_models.TaskStatus": {
             "type": "string",
             "enum": [
                 "pending",
@@ -484,7 +484,7 @@ const docTemplate = `{
                 "TaskStatusFailed"
             ]
         },
-        "models.UserLastActivityResponse": {
+        "github_com_prefeitura-rio_app-eai-agent-gateway_internal_models.UserLastActivityResponse": {
             "type": "object",
             "properties": {
                 "cached": {
@@ -505,7 +505,7 @@ const docTemplate = `{
                 }
             }
         },
-        "models.UserWebhookRequest": {
+        "github_com_prefeitura-rio_app-eai-agent-gateway_internal_models.UserWebhookRequest": {
             "type": "object",
             "required": [
                 "user_number"
@@ -516,7 +516,7 @@ const docTemplate = `{
                     "example": "https://example.com/webhook/callback"
                 },
                 "media": {
-                    "description": "Media carries the media metadata when MessageType is non-text.\nPass-through ` + "`" + `map[string]interface{}` + "`" + ` to avoid coupling to any specific\nupstream schema; serialized as-is into the enriched Message body for the\nLLM to extract. Source upstream: Salesforce Apex (study-sf-whatsapp-poc1)\n→ Mule sc-inbound-flow.\n\nChaves esperadas/conhecidas (mantidas em sync com o tool MCP\n` + "`" + `register_inbound_media` + "`" + ` em prefeitura-rio/app-mcp-server e ADR-012 em\nstudy-sf-whatsapp-poc1). Typos passam silenciosos por design — gateway\né pass-through; validação semântica fica no MCP tool. Atualizar este\ncomentário sempre que o tool aceitar/exigir nova chave.\n\nPra image/audio/video (BSP entrega via ContentVersion auto-attachado):\n  - content_version_id   (string, SF Id 18-char)\n  - content_document_id  (string, SF Id 18-char)\n  - file_extension       (string, lowercase: \"jpg\"|\"png\"|\"oga\"|\"ogg\"|\"mp4\"|...)\n  - file_size_bytes      (number)\n  - download_path        (string, REST path: \"/services/data/v62.0/sobjects/ContentVersion/{Id}/VersionData\")\n\nPra location (atualmente não entregue pelo BSP; placeholder pra BYOC futuro):\n  - latitude             (number, -90..90)\n  - longitude            (number, -180..180)\n  - address              (string, opcional)\n  - name                 (string, opcional — point-of-interest)\n\nPra unsupported/unknown: Media pode ser nil ou {} — tipo já carrega o\nsignal suficiente, sem metadata útil pra MCP processar.",
+                    "description": "Media carries the media metadata when MessageType is non-text.\nPass-through ` + "`" + `map[string]interface{}` + "`" + ` to avoid coupling to any specific\nupstream schema; serialized as-is into the enriched Message body for the\nLLM to extract. Source upstream: Salesforce Apex (study-sf-whatsapp-poc1)\n→ Mule sc-inbound-flow.\n\nChaves esperadas/conhecidas (mantidas em sync com o tool MCP\n` + "`" + `register_inbound_media` + "`" + ` em prefeitura-rio/app-mcp-server e ADR-012 em\nstudy-sf-whatsapp-poc1). Typos passam silenciosos por design — gateway\né pass-through; validação semântica fica no MCP tool. Atualizar este\ncomentário sempre que o tool aceitar/exigir nova chave.\n\nPra image/audio/video (BSP entrega via ContentVersion auto-attachado):\n  - content_version_id   (string, SF Id 18-char)\n  - content_document_id  (string, SF Id 18-char)\n  - file_extension       (string, lowercase: \"jpg\"|\"png\"|\"oga\"|\"ogg\"|\"mp4\"|...)\n  - file_size_bytes      (number)\n  - download_path        (string, REST path: \"/services/data/v62.0/sobjects/ContentVersion/{Id}/VersionData\")\n\nPra location (atualmente não entregue pelo BSP; placeholder pra BYOC futuro):\n  - latitude             (number, -90..90)\n  - longitude            (number, -180..180)\n  - address              (string, opcional)\n  - name                 (string, opcional — point-of-interest)\n\nPra interactive: Media carrega sub-shapes de WhatsApp interactive inbound\n(button_reply, list_reply, nfm_reply/Flow submission) sem validação local.\n\nPra unsupported/unknown: Media pode ser nil ou {} — tipo já carrega o\nsignal suficiente, sem metadata útil pra MCP processar.",
                     "type": "object",
                     "additionalProperties": true
                 },
@@ -526,7 +526,7 @@ const docTemplate = `{
                     "example": "Hello, how can you help me?"
                 },
                 "message_type": {
-                    "description": "MessageType discriminates inbound media kinds when caller (Mule, etc.) sends\nnon-text payloads. Values: \"text\" (default), \"image\", \"audio\", \"video\", \"location\",\n\"unsupported\", \"unknown\". Worker uses it to enrich ` + "`" + `Message` + "`" + ` with an\n[INBOUND_MEDIA] prefix so the downstream LLM can call the MCP tool\n` + "`" + `register_inbound_media` + "`" + `. Optional; absent or \"text\" preserves legacy\nbehavior.",
+                    "description": "MessageType discriminates inbound media kinds when caller (Mule, etc.) sends\nnon-text payloads. Inbound-capable values follow the canonical registry in\nprefeitura-rio/app-mcp-server/media-types.yaml: \"text\", \"audio\", \"image\",\n\"video\", \"location\", \"interactive\". Gateway also accepts sentinel values\n\"unsupported\" and \"unknown\". Worker uses it to enrich ` + "`" + `Message` + "`" + ` with an\n[INBOUND_MEDIA] prefix so the downstream LLM can call MCP tools. Optional;\nabsent or \"text\" preserves legacy behavior.",
                     "type": "string",
                     "example": "image"
                 },
@@ -552,7 +552,7 @@ const docTemplate = `{
                 }
             }
         },
-        "models.WebhookResponse": {
+        "github_com_prefeitura-rio_app-eai-agent-gateway_internal_models.WebhookResponse": {
             "type": "object",
             "properties": {
                 "message_id": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -51,7 +51,7 @@
                     "200": {
                         "description": "Task debug information",
                         "schema": {
-                            "$ref": "#/definitions/models.TaskDebugInfo"
+                            "$ref": "#/definitions/github_com_prefeitura-rio_app-eai-agent-gateway_internal_models.TaskDebugInfo"
                         }
                     },
                     "400": {
@@ -101,7 +101,7 @@
                     "200": {
                         "description": "Last activity timestamp found",
                         "schema": {
-                            "$ref": "#/definitions/models.UserLastActivityResponse"
+                            "$ref": "#/definitions/github_com_prefeitura-rio_app-eai-agent-gateway_internal_models.UserLastActivityResponse"
                         }
                     },
                     "400": {
@@ -154,13 +154,13 @@
                     "200": {
                         "description": "Message completed or failed",
                         "schema": {
-                            "$ref": "#/definitions/models.MessageResponse"
+                            "$ref": "#/definitions/github_com_prefeitura-rio_app-eai-agent-gateway_internal_models.MessageResponse"
                         }
                     },
                     "202": {
                         "description": "Message still processing",
                         "schema": {
-                            "$ref": "#/definitions/models.MessageResponse"
+                            "$ref": "#/definitions/github_com_prefeitura-rio_app-eai-agent-gateway_internal_models.MessageResponse"
                         }
                     },
                     "400": {
@@ -207,7 +207,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.HistoryUpdateWebhookRequest"
+                            "$ref": "#/definitions/github_com_prefeitura-rio_app-eai-agent-gateway_internal_models.HistoryUpdateWebhookRequest"
                         }
                     }
                 ],
@@ -256,7 +256,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.UserWebhookRequest"
+                            "$ref": "#/definitions/github_com_prefeitura-rio_app-eai-agent-gateway_internal_models.UserWebhookRequest"
                         }
                     }
                 ],
@@ -264,7 +264,7 @@
                     "202": {
                         "description": "Message queued successfully",
                         "schema": {
-                            "$ref": "#/definitions/models.WebhookResponse"
+                            "$ref": "#/definitions/github_com_prefeitura-rio_app-eai-agent-gateway_internal_models.WebhookResponse"
                         }
                     },
                     "400": {
@@ -372,7 +372,7 @@
         }
     },
     "definitions": {
-        "models.HistoryMessage": {
+        "github_com_prefeitura-rio_app-eai-agent-gateway_internal_models.HistoryMessage": {
             "type": "object",
             "required": [
                 "content",
@@ -389,7 +389,7 @@
                 }
             }
         },
-        "models.HistoryUpdateWebhookRequest": {
+        "github_com_prefeitura-rio_app-eai-agent-gateway_internal_models.HistoryUpdateWebhookRequest": {
             "type": "object",
             "required": [
                 "messages",
@@ -400,7 +400,7 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "#/definitions/models.HistoryMessage"
+                        "$ref": "#/definitions/github_com_prefeitura-rio_app-eai-agent-gateway_internal_models.HistoryMessage"
                     }
                 },
                 "metadata": {
@@ -417,7 +417,7 @@
                 }
             }
         },
-        "models.MessageResponse": {
+        "github_com_prefeitura-rio_app-eai-agent-gateway_internal_models.MessageResponse": {
             "description": "Message processing response",
             "type": "object",
             "properties": {
@@ -434,7 +434,7 @@
                 }
             }
         },
-        "models.TaskDebugInfo": {
+        "github_com_prefeitura-rio_app-eai-agent-gateway_internal_models.TaskDebugInfo": {
             "type": "object",
             "properties": {
                 "created_at": {
@@ -460,14 +460,14 @@
                     "type": "integer"
                 },
                 "status": {
-                    "$ref": "#/definitions/models.TaskStatus"
+                    "$ref": "#/definitions/github_com_prefeitura-rio_app-eai-agent-gateway_internal_models.TaskStatus"
                 },
                 "updated_at": {
                     "type": "string"
                 }
             }
         },
-        "models.TaskStatus": {
+        "github_com_prefeitura-rio_app-eai-agent-gateway_internal_models.TaskStatus": {
             "type": "string",
             "enum": [
                 "pending",
@@ -482,7 +482,7 @@
                 "TaskStatusFailed"
             ]
         },
-        "models.UserLastActivityResponse": {
+        "github_com_prefeitura-rio_app-eai-agent-gateway_internal_models.UserLastActivityResponse": {
             "type": "object",
             "properties": {
                 "cached": {
@@ -503,7 +503,7 @@
                 }
             }
         },
-        "models.UserWebhookRequest": {
+        "github_com_prefeitura-rio_app-eai-agent-gateway_internal_models.UserWebhookRequest": {
             "type": "object",
             "required": [
                 "user_number"
@@ -514,7 +514,7 @@
                     "example": "https://example.com/webhook/callback"
                 },
                 "media": {
-                    "description": "Media carries the media metadata when MessageType is non-text.\nPass-through `map[string]interface{}` to avoid coupling to any specific\nupstream schema; serialized as-is into the enriched Message body for the\nLLM to extract. Source upstream: Salesforce Apex (study-sf-whatsapp-poc1)\n→ Mule sc-inbound-flow.\n\nChaves esperadas/conhecidas (mantidas em sync com o tool MCP\n`register_inbound_media` em prefeitura-rio/app-mcp-server e ADR-012 em\nstudy-sf-whatsapp-poc1). Typos passam silenciosos por design — gateway\né pass-through; validação semântica fica no MCP tool. Atualizar este\ncomentário sempre que o tool aceitar/exigir nova chave.\n\nPra image/audio/video (BSP entrega via ContentVersion auto-attachado):\n  - content_version_id   (string, SF Id 18-char)\n  - content_document_id  (string, SF Id 18-char)\n  - file_extension       (string, lowercase: \"jpg\"|\"png\"|\"oga\"|\"ogg\"|\"mp4\"|...)\n  - file_size_bytes      (number)\n  - download_path        (string, REST path: \"/services/data/v62.0/sobjects/ContentVersion/{Id}/VersionData\")\n\nPra location (atualmente não entregue pelo BSP; placeholder pra BYOC futuro):\n  - latitude             (number, -90..90)\n  - longitude            (number, -180..180)\n  - address              (string, opcional)\n  - name                 (string, opcional — point-of-interest)\n\nPra unsupported/unknown: Media pode ser nil ou {} — tipo já carrega o\nsignal suficiente, sem metadata útil pra MCP processar.",
+                    "description": "Media carries the media metadata when MessageType is non-text.\nPass-through `map[string]interface{}` to avoid coupling to any specific\nupstream schema; serialized as-is into the enriched Message body for the\nLLM to extract. Source upstream: Salesforce Apex (study-sf-whatsapp-poc1)\n→ Mule sc-inbound-flow.\n\nChaves esperadas/conhecidas (mantidas em sync com o tool MCP\n`register_inbound_media` em prefeitura-rio/app-mcp-server e ADR-012 em\nstudy-sf-whatsapp-poc1). Typos passam silenciosos por design — gateway\né pass-through; validação semântica fica no MCP tool. Atualizar este\ncomentário sempre que o tool aceitar/exigir nova chave.\n\nPra image/audio/video (BSP entrega via ContentVersion auto-attachado):\n  - content_version_id   (string, SF Id 18-char)\n  - content_document_id  (string, SF Id 18-char)\n  - file_extension       (string, lowercase: \"jpg\"|\"png\"|\"oga\"|\"ogg\"|\"mp4\"|...)\n  - file_size_bytes      (number)\n  - download_path        (string, REST path: \"/services/data/v62.0/sobjects/ContentVersion/{Id}/VersionData\")\n\nPra location (atualmente não entregue pelo BSP; placeholder pra BYOC futuro):\n  - latitude             (number, -90..90)\n  - longitude            (number, -180..180)\n  - address              (string, opcional)\n  - name                 (string, opcional — point-of-interest)\n\nPra interactive: Media carrega sub-shapes de WhatsApp interactive inbound\n(button_reply, list_reply, nfm_reply/Flow submission) sem validação local.\n\nPra unsupported/unknown: Media pode ser nil ou {} — tipo já carrega o\nsignal suficiente, sem metadata útil pra MCP processar.",
                     "type": "object",
                     "additionalProperties": true
                 },
@@ -524,7 +524,7 @@
                     "example": "Hello, how can you help me?"
                 },
                 "message_type": {
-                    "description": "MessageType discriminates inbound media kinds when caller (Mule, etc.) sends\nnon-text payloads. Values: \"text\" (default), \"image\", \"audio\", \"video\", \"location\",\n\"unsupported\", \"unknown\". Worker uses it to enrich `Message` with an\n[INBOUND_MEDIA] prefix so the downstream LLM can call the MCP tool\n`register_inbound_media`. Optional; absent or \"text\" preserves legacy\nbehavior.",
+                    "description": "MessageType discriminates inbound media kinds when caller (Mule, etc.) sends\nnon-text payloads. Inbound-capable values follow the canonical registry in\nprefeitura-rio/app-mcp-server/media-types.yaml: \"text\", \"audio\", \"image\",\n\"video\", \"location\", \"interactive\". Gateway also accepts sentinel values\n\"unsupported\" and \"unknown\". Worker uses it to enrich `Message` with an\n[INBOUND_MEDIA] prefix so the downstream LLM can call MCP tools. Optional;\nabsent or \"text\" preserves legacy behavior.",
                     "type": "string",
                     "example": "image"
                 },
@@ -550,7 +550,7 @@
                 }
             }
         },
-        "models.WebhookResponse": {
+        "github_com_prefeitura-rio_app-eai-agent-gateway_internal_models.WebhookResponse": {
             "type": "object",
             "properties": {
                 "message_id": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,6 +1,6 @@
 basePath: /
 definitions:
-  models.HistoryMessage:
+  github_com_prefeitura-rio_app-eai-agent-gateway_internal_models.HistoryMessage:
     properties:
       content:
         example: Hello, World!
@@ -12,11 +12,11 @@ definitions:
     - content
     - role
     type: object
-  models.HistoryUpdateWebhookRequest:
+  github_com_prefeitura-rio_app-eai-agent-gateway_internal_models.HistoryUpdateWebhookRequest:
     properties:
       messages:
         items:
-          $ref: '#/definitions/models.HistoryMessage'
+          $ref: '#/definitions/github_com_prefeitura-rio_app-eai-agent-gateway_internal_models.HistoryMessage'
         minItems: 1
         type: array
       metadata:
@@ -32,7 +32,7 @@ definitions:
     - messages
     - user_number
     type: object
-  models.MessageResponse:
+  github_com_prefeitura-rio_app-eai-agent-gateway_internal_models.MessageResponse:
     description: Message processing response
     properties:
       data:
@@ -44,7 +44,7 @@ definitions:
         example: completed
         type: string
     type: object
-  models.TaskDebugInfo:
+  github_com_prefeitura-rio_app-eai-agent-gateway_internal_models.TaskDebugInfo:
     properties:
       created_at:
         type: string
@@ -62,11 +62,11 @@ definitions:
       retry_count:
         type: integer
       status:
-        $ref: '#/definitions/models.TaskStatus'
+        $ref: '#/definitions/github_com_prefeitura-rio_app-eai-agent-gateway_internal_models.TaskStatus'
       updated_at:
         type: string
     type: object
-  models.TaskStatus:
+  github_com_prefeitura-rio_app-eai-agent-gateway_internal_models.TaskStatus:
     enum:
     - pending
     - processing
@@ -78,7 +78,7 @@ definitions:
     - TaskStatusProcessing
     - TaskStatusCompleted
     - TaskStatusFailed
-  models.UserLastActivityResponse:
+  github_com_prefeitura-rio_app-eai-agent-gateway_internal_models.UserLastActivityResponse:
     properties:
       cached:
         example: true
@@ -93,7 +93,7 @@ definitions:
         example: "5521999999999"
         type: string
     type: object
-  models.UserWebhookRequest:
+  github_com_prefeitura-rio_app-eai-agent-gateway_internal_models.UserWebhookRequest:
     properties:
       callback_url:
         example: https://example.com/webhook/callback
@@ -126,6 +126,9 @@ definitions:
             - address              (string, opcional)
             - name                 (string, opcional — point-of-interest)
 
+          Pra interactive: Media carrega sub-shapes de WhatsApp interactive inbound
+          (button_reply, list_reply, nfm_reply/Flow submission) sem validação local.
+
           Pra unsupported/unknown: Media pode ser nil ou {} — tipo já carrega o
           signal suficiente, sem metadata útil pra MCP processar.
         type: object
@@ -141,11 +144,12 @@ definitions:
       message_type:
         description: |-
           MessageType discriminates inbound media kinds when caller (Mule, etc.) sends
-          non-text payloads. Values: "text" (default), "image", "audio", "video", "location",
-          "unsupported", "unknown". Worker uses it to enrich `Message` with an
-          [INBOUND_MEDIA] prefix so the downstream LLM can call the MCP tool
-          `register_inbound_media`. Optional; absent or "text" preserves legacy
-          behavior.
+          non-text payloads. Inbound-capable values follow the canonical registry in
+          prefeitura-rio/app-mcp-server/media-types.yaml: "text", "audio", "image",
+          "video", "location", "interactive". Gateway also accepts sentinel values
+          "unsupported" and "unknown". Worker uses it to enrich `Message` with an
+          [INBOUND_MEDIA] prefix so the downstream LLM can call MCP tools. Optional;
+          absent or "text" preserves legacy behavior.
         example: image
         type: string
       metadata:
@@ -166,7 +170,7 @@ definitions:
     required:
     - user_number
     type: object
-  models.WebhookResponse:
+  github_com_prefeitura-rio_app-eai-agent-gateway_internal_models.WebhookResponse:
     properties:
       message_id:
         example: 123e4567-e89b-12d3-a456-426614174000
@@ -209,7 +213,7 @@ paths:
         "200":
           description: Task debug information
           schema:
-            $ref: '#/definitions/models.TaskDebugInfo'
+            $ref: '#/definitions/github_com_prefeitura-rio_app-eai-agent-gateway_internal_models.TaskDebugInfo'
         "400":
           description: Invalid request or message ID format
           schema:
@@ -244,7 +248,7 @@ paths:
         "200":
           description: Last activity timestamp found
           schema:
-            $ref: '#/definitions/models.UserLastActivityResponse'
+            $ref: '#/definitions/github_com_prefeitura-rio_app-eai-agent-gateway_internal_models.UserLastActivityResponse'
         "400":
           description: Invalid request
           schema:
@@ -280,11 +284,11 @@ paths:
         "200":
           description: Message completed or failed
           schema:
-            $ref: '#/definitions/models.MessageResponse'
+            $ref: '#/definitions/github_com_prefeitura-rio_app-eai-agent-gateway_internal_models.MessageResponse'
         "202":
           description: Message still processing
           schema:
-            $ref: '#/definitions/models.MessageResponse'
+            $ref: '#/definitions/github_com_prefeitura-rio_app-eai-agent-gateway_internal_models.MessageResponse'
         "400":
           description: Invalid request or message ID format
           schema:
@@ -314,7 +318,7 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/models.HistoryUpdateWebhookRequest'
+          $ref: '#/definitions/github_com_prefeitura-rio_app-eai-agent-gateway_internal_models.HistoryUpdateWebhookRequest'
       produces:
       - application/json
       responses:
@@ -347,14 +351,14 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/models.UserWebhookRequest'
+          $ref: '#/definitions/github_com_prefeitura-rio_app-eai-agent-gateway_internal_models.UserWebhookRequest'
       produces:
       - application/json
       responses:
         "202":
           description: Message queued successfully
           schema:
-            $ref: '#/definitions/models.WebhookResponse'
+            $ref: '#/definitions/github_com_prefeitura-rio_app-eai-agent-gateway_internal_models.WebhookResponse'
         "400":
           description: Invalid request
           schema:

--- a/internal/handlers/message.go
+++ b/internal/handlers/message.go
@@ -104,15 +104,11 @@ func (h *MessageHandler) HandleUserWebhook(c *gin.Context) {
 	// de virarem prefix [INBOUND_MEDIA] malformado pro LLM downstream.
 	if req.MessageType != nil && *req.MessageType != "" {
 		mt := *req.MessageType
-		valid := map[string]bool{
-			"text": true, "image": true, "audio": true, "video": true,
-			"location": true, "unsupported": true, "unknown": true,
-		}
-		if !valid[mt] {
+		if !models.IsKnownMessageType(mt) {
 			h.logger.WithField("message_type", mt).Error("Invalid message_type")
 			c.JSON(http.StatusBadRequest, gin.H{
 				"error":   "Invalid request",
-				"message": "message_type must be one of: text, image, audio, video, location, unsupported, unknown",
+				"message": "message_type must be one of: " + models.KnownMessageTypesDescription(),
 			})
 			return
 		}
@@ -127,12 +123,11 @@ func (h *MessageHandler) HandleUserWebhook(c *gin.Context) {
 	// "unsupported" e "unknown" sao tipos sentinela: BSP injetou texto fake
 	// ou Apex falhou em correlacionar ContentVersion. Nao precisam de Media
 	// populado por design — Message=null + classificacao pelo tipo basta pra
-	// telemetria/log. Os tipos "midia real" (image, audio, video, location)
-	// requerem len(req.Media) > 0 (ex: content_version_id, lat/lng).
-	noMediaTypesAllowed := req.MessageType != nil &&
-		(*req.MessageType == "unsupported" || *req.MessageType == "unknown")
+	// telemetria/log. Os tipos "midia real" (image, audio, video, location,
+	// interactive) requerem len(req.Media) > 0.
+	emptyMediaAllowed := req.MessageType != nil && models.AllowsEmptyMedia(*req.MessageType)
 	hasMedia := req.MessageType != nil && *req.MessageType != "" && *req.MessageType != "text" &&
-		(len(req.Media) > 0 || noMediaTypesAllowed)
+		(len(req.Media) > 0 || emptyMediaAllowed)
 	if !hasText && !hasMedia {
 		h.logger.Error("User webhook payload has neither text nor media")
 		c.JSON(http.StatusBadRequest, gin.H{

--- a/internal/models/message.go
+++ b/internal/models/message.go
@@ -1,10 +1,50 @@
 package models
 
 import (
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
 )
+
+// KnownMessageTypesList mirrors inbound-capable media types from
+// prefeitura-rio/app-mcp-server/media-types.yaml plus Gateway sentinel values.
+// Gateway intentionally remains pass-through for media payload shape; semantic
+// validation belongs to MCP tools.
+var KnownMessageTypesList = []string{
+	"text",
+	"audio",
+	"image",
+	"video",
+	"location",
+	"interactive",
+	"unsupported",
+	"unknown",
+}
+
+var knownMessageTypesSet = func() map[string]bool {
+	set := make(map[string]bool, len(KnownMessageTypesList))
+	for _, messageType := range KnownMessageTypesList {
+		set[messageType] = true
+	}
+	return set
+}()
+
+// IsKnownMessageType reports whether message_type is supported by the Gateway
+// input contract. Empty is allowed because absent message_type preserves legacy
+// text behavior.
+func IsKnownMessageType(messageType string) bool {
+	if messageType == "" {
+		return true
+	}
+	return knownMessageTypesSet[messageType]
+}
+
+// AllowsEmptyMedia reports whether message_type can carry only its sentinel
+// classification without a media metadata object.
+func AllowsEmptyMedia(messageType string) bool {
+	return messageType == "unsupported" || messageType == "unknown"
+}
 
 // HistoryMessage represents a single message in the history update
 type HistoryMessage struct {
@@ -22,8 +62,8 @@ type HistoryUpdateWebhookRequest struct {
 
 // UserWebhookRequest represents the request payload for user webhook (matches Python API)
 type UserWebhookRequest struct {
-	UserNumber        string                 `json:"user_number" binding:"required" example:"5521999999999"`
-	PreviousMessage   *string                `json:"previous_message,omitempty" example:"Previous message context"`
+	UserNumber      string  `json:"user_number" binding:"required" example:"5521999999999"`
+	PreviousMessage *string `json:"previous_message,omitempty" example:"Previous message context"`
 	// Message is optional when MessageType != "text" and Media is provided
 	// (media-only payloads, e.g. raw image without caption). Handler enforces
 	// "either Message non-empty OR (MessageType non-text + Media)" semantic
@@ -35,11 +75,12 @@ type UserWebhookRequest struct {
 	CallbackURL       *string                `json:"callback_url,omitempty" binding:"omitempty,url" example:"https://example.com/webhook/callback"`
 	ReasoningEngineID *string                `json:"reasoning_engine_id,omitempty" example:"12345678"`
 	// MessageType discriminates inbound media kinds when caller (Mule, etc.) sends
-	// non-text payloads. Values: "text" (default), "image", "audio", "video",
-	// "location", "unsupported", "unknown". Worker uses it to enrich `Message`
-	// with an [INBOUND_MEDIA] prefix so the downstream LLM can call the MCP
-	// tool `register_inbound_media`. Optional; absent or "text" preserves
-	// legacy behavior.
+	// non-text payloads. Inbound-capable values follow the canonical registry in
+	// prefeitura-rio/app-mcp-server/media-types.yaml: "text", "audio", "image",
+	// "video", "location", "interactive". Gateway also accepts sentinel values
+	// "unsupported" and "unknown". Worker uses it to enrich `Message` with an
+	// [INBOUND_MEDIA] prefix so the downstream LLM can call MCP tools. Optional;
+	// absent or "text" preserves legacy behavior.
 	MessageType *string `json:"message_type,omitempty" example:"image"`
 	// Media carries the media metadata when MessageType is non-text.
 	// Pass-through `map[string]interface{}` to avoid coupling to any specific
@@ -66,9 +107,16 @@ type UserWebhookRequest struct {
 	//   - address              (string, opcional)
 	//   - name                 (string, opcional — point-of-interest)
 	//
+	// Pra interactive: Media carrega sub-shapes de WhatsApp interactive inbound
+	// (button_reply, list_reply, nfm_reply/Flow submission) sem validação local.
+	//
 	// Pra unsupported/unknown: Media pode ser nil ou {} — tipo já carrega o
 	// signal suficiente, sem metadata útil pra MCP processar.
 	Media map[string]interface{} `json:"media,omitempty"`
+}
+
+func KnownMessageTypesDescription() string {
+	return strings.Join(KnownMessageTypesList, ", ")
 }
 
 // WebhookResponse represents the response for webhook endpoints (matches Python API)

--- a/internal/models/message_test.go
+++ b/internal/models/message_test.go
@@ -1,0 +1,52 @@
+package models
+
+import "testing"
+
+func TestIsKnownMessageType(t *testing.T) {
+	tests := []struct {
+		name        string
+		messageType string
+		want        bool
+	}{
+		{name: "empty preserves legacy text behavior", messageType: "", want: true},
+		{name: "text", messageType: "text", want: true},
+		{name: "audio", messageType: "audio", want: true},
+		{name: "image", messageType: "image", want: true},
+		{name: "video", messageType: "video", want: true},
+		{name: "location", messageType: "location", want: true},
+		{name: "interactive", messageType: "interactive", want: true},
+		{name: "unsupported sentinel", messageType: "unsupported", want: true},
+		{name: "unknown sentinel", messageType: "unknown", want: true},
+		{name: "typo", messageType: "imgae", want: false},
+		{name: "outbound-only registry type", messageType: "document", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsKnownMessageType(tt.messageType); got != tt.want {
+				t.Fatalf("IsKnownMessageType(%q) = %v, want %v", tt.messageType, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAllowsEmptyMedia(t *testing.T) {
+	tests := []struct {
+		messageType string
+		want        bool
+	}{
+		{messageType: "unsupported", want: true},
+		{messageType: "unknown", want: true},
+		{messageType: "interactive", want: false},
+		{messageType: "image", want: false},
+		{messageType: "", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.messageType, func(t *testing.T) {
+			if got := AllowsEmptyMedia(tt.messageType); got != tt.want {
+				t.Fatalf("AllowsEmptyMedia(%q) = %v, want %v", tt.messageType, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Alinha o contrato inbound do Gateway com o `media-types.yaml` canônico recém-mergeado no `app-mcp-server`.

O Gateway já era majoritariamente pass-through para mídia (`media: map[string]interface{}` + prefix `[INBOUND_MEDIA]`), mas ainda rejeitava `message_type=interactive` no enum fechado do handler. Isso quebraria WhatsApp Flow/button/list antes de chegar no Engine, apesar de `interactive` agora existir como inbound no registry MCP.

Mudanças:
- aceita `message_type=interactive` no contrato inbound;
- centraliza a lista de message types em `internal/models` para evitar drift entre handler, erro HTTP e docs;
- mantém validação semântica do shape `media` fora do Gateway, como pass-through para Engine/MCP;
- adiciona testes unitários do contrato de `message_type`;
- regenera Swagger.

## Validation
- [x] `go test ./internal/models ./internal/handlers ./internal/handlers/workers ./internal/workers`
- [x] `go test ./...`
- [x] `~/go/bin/swag init -g cmd/gateway/main.go -o docs --parseDependency --parseInternal`
- [x] `codex review --uncommitted` clean

## Notes
Outbound continua fora do Gateway: Engine faz callback para Mule, e Mule interpreta `agentMedia`. Esta PR corrige só a entrada Mule -> Gateway -> Engine para não bloquear `interactive` inbound.
