### PR TITLE
feat(meta-direct): Gateway-as-broker 100% — full outbound + Flow registry + serialization + anti-loop

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -159,3 +159,37 @@ DATA_RELAY_API_KEY=your-data-relay-api-key
 DATA_RELAY_TIMEOUT=10
 DATA_RELAY_SOURCE=eai-agent-gateway
 DATA_RELAY_FLOW_NAME=wetalkie_callback
+
+# ==============================================================================
+# Meta WhatsApp Business Cloud — Direct Integration (PR #32)
+# ==============================================================================
+# Quando META_DIRECT_ENABLED=true, Gateway substitui Mule como broker entre
+# Meta e Engine. Rotas registradas: GET/POST /meta/webhook + POST /meta/dispatch.
+# Default false → rotas não registradas, comportamento atual preservado.
+# Fail-loud no startup se ENABLED=true mas chain incompleta.
+META_DIRECT_ENABLED=false
+META_WEBHOOK_VERIFY_TOKEN=your-meta-webhook-verify-token
+META_WEBHOOK_APP_SECRET=your-meta-app-secret
+META_SYSTEM_USER_TOKEN=your-meta-system-user-token
+META_PHONE_NUMBER_ID=your-waba-phone-number-id
+META_GRAPH_API_VERSION=v21.0
+# URL pública do próprio Gateway pro endpoint /meta/dispatch.
+# Ex: https://services.pref.rio/eai-agent-gateway/meta/dispatch
+META_SELF_CALLBACK_URL=https://your-gateway-host/meta/dispatch
+# Shared secret pra header X-Meta-Dispatch-Secret (fail-closed se vazio/placeholder).
+META_DISPATCH_SECRET=your-meta-dispatch-secret
+# WhatsApp Flow → service_name dispatch registry (ADR-024).
+# Formato: "flow_name1:service_name1;flow_name2:service_name2"
+META_FLOW_REGISTRY=luminaria:reparo_luminaria
+META_FLOW_DEFAULT_SERVICE=default_service
+
+# ==============================================================================
+# Salesforce Broker Master Switch (ADR-030 — companion PR #22 em study-sf)
+# ==============================================================================
+# Fonte de verdade do switch arquitetural Salesforce-broker vs 100% Meta-direto.
+# Default true preserva comportamento de staging (Salesforce como broker).
+# Mule polla GET /admin/broker-mode a cada 30s pra propagar mudança <1min.
+SALESFORCE_BROKER_ENABLED=true
+# Shared secret pra header X-Admin-Token. Fail-closed: vazio/placeholder = 503.
+# Mesmo valor que vai em broker.modeAuthToken no Mule Runtime Manager.
+ADMIN_API_TOKEN=your-admin-api-token

--- a/docs/meta-direct-cutover.md
+++ b/docs/meta-direct-cutover.md
@@ -1,0 +1,171 @@
+# Meta-direct cutover — checklist operacional (PR #32 + companion #22)
+
+Sequência exata pra ligar `META_DIRECT_ENABLED=true` em staging/prod sem
+quebrar o tráfego atual. Companion: ADR-030 no repo `study-sf-whatsapp-poc1`.
+
+## Pré-requisitos (antes de qualquer merge)
+
+### Gateway K8s secret `eai-agent-gateway-secrets`
+
+```bash
+# Operador adiciona as 8 vars novas no secret K8s (Infisical → sync K8s).
+# Sem isso o pod sobe, mas features novas ficam dormentes.
+kubectl edit secret eai-agent-gateway-secrets -n <namespace>
+```
+
+Adicionar (base64-encoded conforme padrão K8s secret):
+
+| Variável | Origem | Quando obrigatória |
+|---|---|---|
+| `META_WEBHOOK_VERIFY_TOKEN` | Meta App config (qualquer string forte) | Antes do flip `META_DIRECT_ENABLED=true` |
+| `META_WEBHOOK_APP_SECRET` | Meta App → Settings → App Secret | Antes do flip |
+| `META_SYSTEM_USER_TOKEN` | Meta Business Manager → System User → Bearer token | Antes do flip |
+| `META_PHONE_NUMBER_ID` | Meta WABA → Phone Numbers (não-secreto) | Antes do flip |
+| `META_SELF_CALLBACK_URL` | URL pública do próprio Gateway | Antes do flip |
+| `META_DISPATCH_SECRET` | Gerar string forte 32+ chars | Antes do flip |
+| `ADMIN_API_TOKEN` | Gerar string forte 32+ chars | Antes de mergear PR #22 |
+| `META_FLOW_REGISTRY` (opcional) | Formato `luminaria:reparo_luminaria` | Pra Flow Luminária |
+
+**Default seguro**: pod sobe sem nenhuma dessas. `META_DIRECT_ENABLED=false`
+default. Endpoint `/admin/broker-mode` responde 503 até `ADMIN_API_TOKEN`
+populado — Mule trata como degraded e cai pro fallback estático.
+
+### Mule Runtime Manager Properties (após merge PR #22 + redeploy Mule)
+
+```
+broker.modeHost = services.staging.app.dados.rio   # ou services.pref.rio em prod
+broker.modePath = /eai-agent-gateway/admin/broker-mode
+broker.modeAuthToken = <mesmo valor de ADMIN_API_TOKEN do Gateway>
+broker.salesforceBrokerEnabledFallback = true       # default; preserva SF ON em outage Gateway
+```
+
+### Salesforce (Anonymous Apex pós-deploy)
+
+```apex
+// 1. Popular Custom Setting:
+Broker_Mode_Config__c cfg = Broker_Mode_Config__c.getOrgDefaults();
+if (cfg == null) cfg = new Broker_Mode_Config__c();
+cfg.SetupOwnerId = UserInfo.getOrganizationId();
+cfg.Endpoint_URL__c = 'https://services.staging.app.dados.rio/eai-agent-gateway/admin/broker-mode';
+cfg.Admin_API_Token__c = '<mesmo valor de ADMIN_API_TOKEN>';
+upsert cfg;
+
+// 2. Assign Permission Set ao Automated Process user (CRÍTICO):
+PermissionSet ps = [SELECT Id FROM PermissionSet WHERE Name = 'Chatbot_Pipeline_Access' LIMIT 1];
+User autoUser = [SELECT Id FROM User WHERE Alias = 'autoproc' LIMIT 1];
+insert new PermissionSetAssignment(AssigneeId = autoUser.Id, PermissionSetId = ps.Id);
+
+// 3. Confirmar:
+System.debug([SELECT Assignee.Name FROM PermissionSetAssignment
+              WHERE PermissionSet.Name = 'Chatbot_Pipeline_Access']);
+```
+
+## Sequência de merge
+
+### Passo 1 — Merge PR #32 (Gateway)
+- Endpoint `/admin/broker-mode` fica disponível pra Mule pollar.
+- `META_DIRECT_ENABLED` continua `false` default → rotas `/meta/*` NÃO
+  registradas. Comportamento idêntico ao staging atual.
+- Smoke pós-deploy (5min):
+  ```bash
+  # 1. Pod boot sem warn de chain incompleta:
+  kubectl logs -l app=gateway -n <ns> | grep meta_direct_chain_incomplete
+
+  # 2. Health:
+  curl -fsS https://<gateway-host>/health
+
+  # 3. Admin endpoint (com token):
+  curl -fsS -H "X-Admin-Token: $ADMIN_API_TOKEN" \
+    https://<gateway-host>/admin/broker-mode
+  # Expected: {"salesforce_broker_enabled":true,"updated_at":"..."}
+
+  # 4. Path legacy continua funcionando:
+  curl -fsS -X POST https://<gateway-host>/api/v1/message/webhook/user \
+    -H 'Content-Type: application/json' \
+    -d '{"user_number":"+5521xxxxxxxxx","message":"smoke","provider":"google_agent_engine"}'
+  ```
+
+### Passo 2 — Merge PR #22 (study-sf — Mule + Apex)
+- Redeploy Mule via `bash components/mulesoft/scripts/deploy-cloudhub.sh`.
+- Deploy Apex via `sf project deploy start --target-org qa`.
+- Smoke pós-deploy (10min):
+  ```bash
+  # 1. CloudHub log Mule: poll a cada 30s funcionando:
+  # Esperado: event=broker_mode_polled salesforce_broker_enabled=true
+
+  # 2. Apex async log:
+  # Esperado: BrokerGatedPollQueueable rodando + runPollWork sem skip
+  # (assume broker=true pelo fail-safe)
+  ```
+
+### Passo 3 — Configurar Custom Setting + PS no SF (opcional, opt-in)
+- Sem essa config, Apex assume broker ON (fail-safe) e auto-suspend nunca dispara.
+- Com a config: quando `SALESFORCE_BROKER_ENABLED=false` for setado,
+  `ConversationPollSchedulable` pula o trabalho real e zera quota SF.
+
+## Flip operacional (depois dos 3 passos)
+
+### Ligar Meta-direct mode (manter Salesforce broker ON)
+
+```bash
+# Infisical → eai-agent-gateway/staging:
+META_DIRECT_ENABLED=true
+# (+ todas as outras META_* já populadas)
+```
+
+Pod reinicia. Logs esperados:
+- `event=meta_direct_enabled` ✓
+- Sem `event=meta_direct_chain_incomplete` ✓
+
+Apontar Meta App Callback URL pro Gateway:
+- Meta App Dashboard → WhatsApp → Configuration → Webhook URL =
+  `https://<gateway-host>/meta/webhook`
+- Verify Token = `META_WEBHOOK_VERIFY_TOKEN`
+- Subscribe to `messages` field.
+
+Após verify handshake OK, Gateway recebe inbound direto.
+
+### Desligar Salesforce broker (100% Meta-direto)
+
+```bash
+# Infisical:
+SALESFORCE_BROKER_ENABLED=false
+```
+
+Pod reinicia. Em <60s:
+- Mule poll pega novo valor → Object Store atualiza
+- `/sc/inbound` no Mule passa a rejeitar 503
+- Callback Mule força Meta Graph (skip SCRT)
+- Handoff pula Case creation
+- Apex (se Custom Setting populado) auto-suspende `runPollWork`
+
+### Reverter
+
+```bash
+# Volta a Salesforce broker (idempotente):
+SALESFORCE_BROKER_ENABLED=true
+```
+
+Propaga em <60s pelos mesmos paths.
+
+### Reverter completo (desliga Meta-direct)
+
+```bash
+META_DIRECT_ENABLED=false
+```
+
+Pod reinicia. Rotas `/meta/*` deixam de ser registradas. Operador
+reaponta Meta App Callback URL pro Mule manualmente (operação no Meta
+App Dashboard, não tem API).
+
+## Rollback emergencial dos PRs
+
+```bash
+# Em caso de regressão grave:
+git revert <merge-sha-pr-32>  # Gateway
+git revert <merge-sha-pr-22>  # study-sf
+# Push em staging, redeploy.
+```
+
+Custom Setting + Remote Sites do SF são additions seguras — operador apaga
+via Setup UI se quiser limpar.

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	cloud.google.com/go/speech v1.28.0
 	github.com/gin-gonic/gin v1.10.1
 	github.com/google/uuid v1.6.0
+	github.com/lib/pq v1.12.0
 	github.com/prometheus/client_golang v1.23.0
 	github.com/rabbitmq/amqp091-go v1.10.0
 	github.com/redis/go-redis/v9 v9.12.1
@@ -23,6 +24,7 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.37.0
 	go.opentelemetry.io/otel/trace v1.37.0
 	golang.org/x/oauth2 v0.30.0
+	golang.org/x/text v0.26.0
 	google.golang.org/api v0.237.0
 	google.golang.org/genproto v0.0.0-20250505200425-f936aa4a68b2
 )
@@ -68,7 +70,6 @@ require (
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.7 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
-	github.com/lib/pq v1.12.0 // indirect
 	github.com/mailru/easyjson v0.7.6 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
@@ -100,7 +101,6 @@ require (
 	golang.org/x/net v0.41.0 // indirect
 	golang.org/x/sync v0.15.0 // indirect
 	golang.org/x/sys v0.33.0 // indirect
-	golang.org/x/text v0.26.0 // indirect
 	golang.org/x/time v0.12.0 // indirect
 	golang.org/x/tools v0.33.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250603155806-513f23925822 // indirect

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -26,6 +26,9 @@ type Server struct {
 	healthHandler       *handlers.HealthHandler
 	messageHandler      *handlers.MessageHandler
 	userActivityHandler *handlers.UserActivityHandler
+	// metaWebhookHandler é nil quando META_DIRECT_ENABLED=false (default).
+	// POC `feat/meta-direct-poc`: substitui Mule como broker entre Meta e Engine.
+	metaWebhookHandler *handlers.MetaWebhookHandler
 	redisService        *services.RedisService
 	rabbitMQService     *services.RabbitMQService
 	postgresService     *services.PostgresService
@@ -88,6 +91,22 @@ func NewServer(cfg *config.Config, logger *logrus.Logger, otelService *services.
 			return nil
 		}()),
 		userActivityHandler: handlers.NewUserActivityHandler(logger, cfg, redisService, postgresService),
+	}
+
+	// Meta direct integration (POC) — só instancia se feature flag ativa.
+	// Tokens validados de forma laxa aqui; handler faz fail-closed em runtime
+	// se AppSecret ausente.
+	if cfg.Meta.Enabled {
+		server.metaWebhookHandler = handlers.NewMetaWebhookHandler(
+			&cfg.Meta, server.messageHandler, logger,
+		)
+		logger.WithFields(logrus.Fields{
+			"event":             "meta_direct_enabled",
+			"verify_token_set":  cfg.Meta.VerifyToken != "",
+			"app_secret_set":    cfg.Meta.AppSecret != "",
+			"phone_id_set":      cfg.Meta.PhoneNumberID != "",
+			"graph_api_version": cfg.Meta.GraphAPIVersion,
+		}).Info("Meta direct integration enabled")
 	}
 
 	// Add Google Agent Engine to health checks if available
@@ -189,6 +208,15 @@ func (s *Server) setupRoutes() {
 		c.Header("Content-Type", "text/html")
 		c.String(200, html)
 	})
+
+	// Meta WhatsApp Business Cloud direct webhook (POC).
+	// Só registra rotas se META_DIRECT_ENABLED=true E handler instanciado.
+	// Substitui Mule como broker quando Callback URL Meta apontar pro Gateway.
+	if s.metaWebhookHandler != nil {
+		s.router.GET("/meta/webhook", s.metaWebhookHandler.HandleVerify)
+		s.router.POST("/meta/webhook", s.metaWebhookHandler.HandleInbound)
+		s.logger.Info("Meta webhook routes registered: GET+POST /meta/webhook")
+	}
 
 	// API routes group
 	api := s.router.Group("/api")

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -136,19 +136,24 @@ func NewServer(cfg *config.Config, logger *logrus.Logger, otelService *services.
 		// /meta/webhook devolvendo erro (chain parcial), ou via mensagens
 		// silenciosamente órfãs no Redis (SelfCallbackURL ausente).
 		// Espelha dispatchReady() em meta_webhook.go — manter sincronizado.
-		// Placeholder do dispatch secret é tratado como vazio (mesmo gate do
-		// runtime), senão o warn fica suprimido enquanto o webhook silencia
-		// inbound em produção.
-		dispatchSecretEffective := cfg.Meta.DispatchSecret != "" &&
-			cfg.Meta.DispatchSecret != "REPLACE_VIA_RUNTIME_MANAGER_PROPERTIES"
-		if cfg.Meta.SelfCallbackURL == "" || !dispatchSecretEffective ||
-			cfg.Meta.SystemUserToken == "" || cfg.Meta.PhoneNumberID == "" {
+		// Placeholder `REPLACE_VIA_RUNTIME_MANAGER_PROPERTIES` é tratado como
+		// vazio em TODOS os campos sensíveis (não só DispatchSecret), senão o
+		// warn fica suprimido enquanto o webhook silencia inbound em produção
+		// com tokens literais "REPLACE_..." que Meta Graph rejeita.
+		const placeholder = "REPLACE_VIA_RUNTIME_MANAGER_PROPERTIES"
+		notSet := func(v string) bool { return v == "" || v == placeholder }
+		urlIncomplete := notSet(cfg.Meta.SelfCallbackURL)
+		dispatchSecretIncomplete := notSet(cfg.Meta.DispatchSecret)
+		systemUserTokenIncomplete := notSet(cfg.Meta.SystemUserToken)
+		phoneIDIncomplete := notSet(cfg.Meta.PhoneNumberID)
+		if urlIncomplete || dispatchSecretIncomplete ||
+			systemUserTokenIncomplete || phoneIDIncomplete {
 			logger.WithFields(logrus.Fields{
 				"event":                 "meta_direct_chain_incomplete",
-				"self_callback_url_set": cfg.Meta.SelfCallbackURL != "",
-				"dispatch_secret_set":   dispatchSecretEffective,
-				"system_user_token_set": cfg.Meta.SystemUserToken != "",
-				"phone_id_set":          cfg.Meta.PhoneNumberID != "",
+				"self_callback_url_set": !urlIncomplete,
+				"dispatch_secret_set":   !dispatchSecretIncomplete,
+				"system_user_token_set": !systemUserTokenIncomplete,
+				"phone_id_set":          !phoneIDIncomplete,
 			}).Warn("META_DIRECT_ENABLED=true but outbound chain is incomplete; /meta/webhook will reject inbound until all 4 vars are set")
 		}
 	}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -129,15 +129,24 @@ func NewServer(cfg *config.Config, logger *logrus.Logger, otelService *services.
 			"graph_api_version": cfg.Meta.GraphAPIVersion,
 		}).Info("Meta direct integration enabled")
 		// Fail-loud no startup quando flag liga mas chain outbound está
-		// incompleta — sem esse warn, descobre-se só em produção quando
-		// o webhook devolve 503 pra todo inbound (meta_webhook.go:495).
-		if cfg.Meta.DispatchSecret == "" || cfg.Meta.SystemUserToken == "" || cfg.Meta.PhoneNumberID == "" {
+		// incompleta. Sem esse warn, descobre-se só em produção: ou via
+		// /meta/webhook devolvendo erro (chain parcial), ou via mensagens
+		// silenciosamente órfãs no Redis (SelfCallbackURL ausente).
+		// Espelha dispatchReady() em meta_webhook.go — manter sincronizado.
+		// Placeholder do dispatch secret é tratado como vazio (mesmo gate do
+		// runtime), senão o warn fica suprimido enquanto o webhook silencia
+		// inbound em produção.
+		dispatchSecretEffective := cfg.Meta.DispatchSecret != "" &&
+			cfg.Meta.DispatchSecret != "REPLACE_VIA_RUNTIME_MANAGER_PROPERTIES"
+		if cfg.Meta.SelfCallbackURL == "" || !dispatchSecretEffective ||
+			cfg.Meta.SystemUserToken == "" || cfg.Meta.PhoneNumberID == "" {
 			logger.WithFields(logrus.Fields{
 				"event":                 "meta_direct_chain_incomplete",
-				"dispatch_secret_set":   cfg.Meta.DispatchSecret != "",
+				"self_callback_url_set": cfg.Meta.SelfCallbackURL != "",
+				"dispatch_secret_set":   dispatchSecretEffective,
 				"system_user_token_set": cfg.Meta.SystemUserToken != "",
 				"phone_id_set":          cfg.Meta.PhoneNumberID != "",
-			}).Warn("META_DIRECT_ENABLED=true but outbound chain is incomplete; /meta/webhook will reject inbound with 503 until configured")
+			}).Warn("META_DIRECT_ENABLED=true but outbound chain is incomplete; /meta/webhook will reject inbound until all 4 vars are set")
 		}
 	}
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -128,6 +128,17 @@ func NewServer(cfg *config.Config, logger *logrus.Logger, otelService *services.
 			"phone_id_set":      cfg.Meta.PhoneNumberID != "",
 			"graph_api_version": cfg.Meta.GraphAPIVersion,
 		}).Info("Meta direct integration enabled")
+		// Fail-loud no startup quando flag liga mas chain outbound está
+		// incompleta — sem esse warn, descobre-se só em produção quando
+		// o webhook devolve 503 pra todo inbound (meta_webhook.go:495).
+		if cfg.Meta.DispatchSecret == "" || cfg.Meta.SystemUserToken == "" || cfg.Meta.PhoneNumberID == "" {
+			logger.WithFields(logrus.Fields{
+				"event":                 "meta_direct_chain_incomplete",
+				"dispatch_secret_set":   cfg.Meta.DispatchSecret != "",
+				"system_user_token_set": cfg.Meta.SystemUserToken != "",
+				"phone_id_set":          cfg.Meta.PhoneNumberID != "",
+			}).Warn("META_DIRECT_ENABLED=true but outbound chain is incomplete; /meta/webhook will reject inbound with 503 until configured")
+		}
 	}
 
 	// Add Google Agent Engine to health checks if available

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -31,6 +31,9 @@ type Server struct {
 	metaWebhookHandler   *handlers.MetaWebhookHandler
 	metaDispatchHandler  *handlers.MetaDispatchHandler
 	govBrCallbackHandler *handlers.GovBrCallbackHandler
+	// adminBrokerModeHandler — expõe GET /admin/broker-mode pra Mule pollar
+	// e descobrir o estado do master switch SALESFORCE_BROKER_ENABLED.
+	adminBrokerModeHandler *handlers.AdminBrokerModeHandler
 	redisService        *services.RedisService
 	rabbitMQService     *services.RabbitMQService
 	postgresService     *services.PostgresService
@@ -150,6 +153,19 @@ func NewServer(cfg *config.Config, logger *logrus.Logger, otelService *services.
 		}
 	}
 
+	// Admin endpoint — Mule poll a cada 30s pra descobrir broker mode.
+	// Sempre instanciado (mesmo sem ADMIN_API_TOKEN configurado, handler
+	// retorna 503 explícito em vez de 404 indeciso).
+	server.adminBrokerModeHandler = handlers.NewAdminBrokerModeHandler(&cfg.Broker, logger)
+	logger.WithFields(logrus.Fields{
+		"event":                     "broker_mode_initialized",
+		"salesforce_broker_enabled": cfg.Broker.SalesforceBrokerEnabled,
+		"admin_token_configured":    cfg.Broker.AdminAPIToken != "" && cfg.Broker.AdminAPIToken != "REPLACE_VIA_RUNTIME_MANAGER_PROPERTIES",
+	}).Info("Broker master switch loaded")
+	if cfg.Broker.AdminAPIToken == "" || cfg.Broker.AdminAPIToken == "REPLACE_VIA_RUNTIME_MANAGER_PROPERTIES" {
+		logger.Warn("ADMIN_API_TOKEN not configured; GET /admin/broker-mode will return 503 (Mule cannot poll broker state)")
+	}
+
 	// Add Google Agent Engine to health checks if available
 	if googleAgentService != nil {
 		server.healthHandler.AddChecker("google_agent_engine", googleAgentService)
@@ -262,6 +278,11 @@ func (s *Server) setupRoutes() {
 		s.router.POST("/meta/dispatch", s.metaDispatchHandler.HandleDispatch)
 		s.logger.Info("Meta dispatch route registered: POST /meta/dispatch")
 	}
+
+	// Admin — broker mode (Mule polls this every 30s pra propagar o master
+	// switch SALESFORCE_BROKER_ENABLED em <1min sem redeploy).
+	s.router.GET("/admin/broker-mode", s.adminBrokerModeHandler.HandleGet)
+	s.logger.Info("Admin route registered: GET /admin/broker-mode")
 
 	// Gov.br OAuth2/PKCE callback endpoint (outside /api group)
 	// Public endpoint that receives callbacks from Identidade Carioca

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -28,7 +28,8 @@ type Server struct {
 	userActivityHandler *handlers.UserActivityHandler
 	// metaWebhookHandler é nil quando META_DIRECT_ENABLED=false (default).
 	// POC `feat/meta-direct-poc`: substitui Mule como broker entre Meta e Engine.
-	metaWebhookHandler *handlers.MetaWebhookHandler
+	metaWebhookHandler  *handlers.MetaWebhookHandler
+	metaDispatchHandler *handlers.MetaDispatchHandler
 	redisService        *services.RedisService
 	rabbitMQService     *services.RabbitMQService
 	postgresService     *services.PostgresService
@@ -97,9 +98,24 @@ func NewServer(cfg *config.Config, logger *logrus.Logger, otelService *services.
 	// Tokens validados de forma laxa aqui; handler faz fail-closed em runtime
 	// se AppSecret ausente.
 	if cfg.Meta.Enabled {
+		// Redis cumpre o papel de dedup ledger (SETNX wamid). Em testes/POC
+		// sem Redis, passar nil desativa idempotência — Meta retries podem
+		// duplicar processamento, mas o webhook continua funcionando.
+		var dedup handlers.MetaDedupChecker
+		if redisService != nil {
+			dedup = redisService
+		}
 		server.metaWebhookHandler = handlers.NewMetaWebhookHandler(
-			&cfg.Meta, server.messageHandler, logger,
+			&cfg.Meta, server.messageHandler, dedup, logger,
 		)
+		// Outbound dispatcher: worker callback → /meta/dispatch → Meta Graph.
+		// Inicializa apenas se credenciais Meta estão setadas; senão `sender`
+		// fica nil e o endpoint retorna 503.
+		var sender handlers.MetaSender
+		if cfg.Meta.SystemUserToken != "" && cfg.Meta.PhoneNumberID != "" {
+			sender = services.NewMetaGraphService(&cfg.Meta, logger)
+		}
+		server.metaDispatchHandler = handlers.NewMetaDispatchHandler(sender, redisService, cfg.Meta.DispatchSecret, logger)
 		logger.WithFields(logrus.Fields{
 			"event":             "meta_direct_enabled",
 			"verify_token_set":  cfg.Meta.VerifyToken != "",
@@ -216,6 +232,10 @@ func (s *Server) setupRoutes() {
 		s.router.GET("/meta/webhook", s.metaWebhookHandler.HandleVerify)
 		s.router.POST("/meta/webhook", s.metaWebhookHandler.HandleInbound)
 		s.logger.Info("Meta webhook routes registered: GET+POST /meta/webhook")
+	}
+	if s.metaDispatchHandler != nil {
+		s.router.POST("/meta/dispatch", s.metaDispatchHandler.HandleDispatch)
+		s.logger.Info("Meta dispatch route registered: POST /meta/dispatch")
 	}
 
 	// API routes group

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -50,6 +50,23 @@ type Config struct {
 
 	// PostgreSQL (Agent Engine Database)
 	Postgres PostgresConfig `mapstructure:",squash"`
+
+	// Meta (WhatsApp Business Cloud API) — direct integration without Mule broker.
+	// Habilita /meta/webhook GET (verify) + POST (inbound) + outbound via Meta Graph.
+	// Feature flag ENABLED desliga tudo se não houver tokens configurados.
+	Meta MetaConfig `mapstructure:",squash"`
+}
+
+// MetaConfig — credenciais e flags pra Meta WhatsApp Business Cloud API direta.
+// Quando ENABLED=true e tokens válidos presentes, Gateway aceita webhook Meta
+// direto (substituindo Mule como broker do meio).
+type MetaConfig struct {
+	Enabled         bool   `mapstructure:"META_DIRECT_ENABLED"`
+	VerifyToken     string `mapstructure:"META_WEBHOOK_VERIFY_TOKEN"`
+	AppSecret       string `mapstructure:"META_WEBHOOK_APP_SECRET"`
+	SystemUserToken string `mapstructure:"META_SYSTEM_USER_TOKEN"`
+	PhoneNumberID   string `mapstructure:"META_PHONE_NUMBER_ID"`
+	GraphAPIVersion string `mapstructure:"META_GRAPH_API_VERSION"`
 }
 
 type ServerConfig struct {
@@ -262,6 +279,10 @@ func Load() (*Config, error) {
 }
 
 func setDefaults() {
+	// Meta direct integration — defaults off; ativa setando vars no env.
+	viper.SetDefault("META_DIRECT_ENABLED", false)
+	viper.SetDefault("META_GRAPH_API_VERSION", "v21.0")
+
 	// Core Application
 	viper.SetDefault("MAX_PARALLEL", 8)
 
@@ -428,6 +449,14 @@ func validateRequired(config *Config) error {
 // bindEnvironmentVariables explicitly binds environment variables to viper keys
 // This is needed because viper.AutomaticEnv() doesn't work well with nested structs
 func bindEnvironmentVariables() {
+	// Meta direct integration (POC feat/meta-direct-poc)
+	_ = viper.BindEnv("META_DIRECT_ENABLED")
+	_ = viper.BindEnv("META_WEBHOOK_VERIFY_TOKEN")
+	_ = viper.BindEnv("META_WEBHOOK_APP_SECRET")
+	_ = viper.BindEnv("META_SYSTEM_USER_TOKEN")
+	_ = viper.BindEnv("META_PHONE_NUMBER_ID")
+	_ = viper.BindEnv("META_GRAPH_API_VERSION")
+
 	// Core Application
 	_ = viper.BindEnv("APP_PREFIX")
 	_ = viper.BindEnv("MAX_PARALLEL")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -67,6 +67,20 @@ type MetaConfig struct {
 	SystemUserToken string `mapstructure:"META_SYSTEM_USER_TOKEN"`
 	PhoneNumberID   string `mapstructure:"META_PHONE_NUMBER_ID"`
 	GraphAPIVersion string `mapstructure:"META_GRAPH_API_VERSION"`
+	// SelfCallbackURL é a URL pública do próprio Gateway pro endpoint
+	// `/meta/dispatch`. Quando Meta-direct está ativo e o webhook enqueua,
+	// o worker call back para esse endpoint, que faz outbound via Meta Graph.
+	// Em ambientes diferentes setar via env (ex: https://gateway.staging/meta/dispatch).
+	// Vazio = path Meta-direct inbound funciona, outbound não dispara (worker
+	// loga "no callback_url" e a resposta fica órfã em Redis).
+	SelfCallbackURL string `mapstructure:"META_SELF_CALLBACK_URL"`
+	// DispatchSecret é o shared secret que `/meta/dispatch` valida via header
+	// `X-Meta-Dispatch-Secret`. Sem ele, qualquer caller com um `message_id`
+	// válido (que vem na resposta do webhook) poderia POSTar payload fake e
+	// fazer o Gateway enviar texto arbitrário ao usuário via Meta credentials.
+	// Fail-closed: vazio/placeholder → endpoint sempre rejeita 401 (sem auth =
+	// sem outbound).
+	DispatchSecret string `mapstructure:"META_DISPATCH_SECRET"`
 }
 
 type ServerConfig struct {
@@ -456,6 +470,8 @@ func bindEnvironmentVariables() {
 	_ = viper.BindEnv("META_SYSTEM_USER_TOKEN")
 	_ = viper.BindEnv("META_PHONE_NUMBER_ID")
 	_ = viper.BindEnv("META_GRAPH_API_VERSION")
+	_ = viper.BindEnv("META_SELF_CALLBACK_URL")
+	_ = viper.BindEnv("META_DISPATCH_SECRET")
 
 	// Core Application
 	_ = viper.BindEnv("APP_PREFIX")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -58,6 +58,12 @@ type Config struct {
 	// Habilita /meta/webhook GET (verify) + POST (inbound) + outbound via Meta Graph.
 	// Feature flag ENABLED desliga tudo se não houver tokens configurados.
 	Meta MetaConfig `mapstructure:",squash"`
+
+	// Broker — master switch arquitetural pra alternar entre "Salesforce como
+	// broker" (path legacy, Apex+Mule+SCRT) e "100% Meta direto" (Gateway broker).
+	// Source of truth dessa flag é env var via Infisical; outras camadas (Mule)
+	// consultam o endpoint /admin/broker-mode pra propagação <1min sem redeploy.
+	Broker BrokerConfig `mapstructure:",squash"`
 }
 
 // MetaConfig — credenciais e flags pra Meta WhatsApp Business Cloud API direta.
@@ -94,6 +100,27 @@ type MetaConfig struct {
 	// FlowDefaultService é o service_name fallback quando flow_name não bate
 	// nada no FlowRegistry. Match Mule `whatsapp.flow.defaultService`.
 	FlowDefaultService string `mapstructure:"META_FLOW_DEFAULT_SERVICE"`
+}
+
+// BrokerConfig — master switch do papel arquitetural do Salesforce.
+//
+// SalesforceBrokerEnabled=true (default, staging atual):
+//   - Apex Trigger + ConversationPollSchedulable + MuleCalloutQueueable ativos
+//   - Mule /sc/inbound aceita callouts do Apex
+//   - Outbound via SCRT quando hasCorrelation=true
+//   - Case creation no handoff
+//
+// SalesforceBrokerEnabled=false:
+//   - Mule /sc/inbound rejeita 503 (Apex callout vira no-op silencioso)
+//   - Outbound sempre via Meta Graph (skip SCRT mesmo com correlation)
+//   - Handoff não cria Case
+//   - Path canônico é Meta→Mule/Gateway /meta/webhook → Engine → Meta Graph
+//
+// AdminAPIToken protege o endpoint GET /admin/broker-mode (consultado pelo
+// Mule a cada 30s). Fail-closed: vazio/placeholder = endpoint sempre 401.
+type BrokerConfig struct {
+	SalesforceBrokerEnabled bool   `mapstructure:"SALESFORCE_BROKER_ENABLED"`
+	AdminAPIToken           string `mapstructure:"ADMIN_API_TOKEN"`
 }
 
 type ServerConfig struct {
@@ -322,6 +349,12 @@ func setDefaults() {
 	viper.SetDefault("META_DIRECT_ENABLED", false)
 	viper.SetDefault("META_GRAPH_API_VERSION", "v21.0")
 
+	// Broker master switch — default true preserva comportamento atual de
+	// staging (Salesforce broker ativo). Operator vira false via Infisical
+	// pra rodar 100% Meta-direto sem redeploy. Endpoint /admin/broker-mode
+	// requer ADMIN_API_TOKEN (sem default — fail-closed se não setado).
+	viper.SetDefault("SALESFORCE_BROKER_ENABLED", true)
+
 	// Core Application
 	viper.SetDefault("MAX_PARALLEL", 8)
 
@@ -499,6 +532,10 @@ func bindEnvironmentVariables() {
 	_ = viper.BindEnv("META_DISPATCH_SECRET")
 	_ = viper.BindEnv("META_FLOW_REGISTRY")
 	_ = viper.BindEnv("META_FLOW_DEFAULT_SERVICE")
+
+	// Broker master switch (Salesforce as broker vs 100% Meta-direct)
+	_ = viper.BindEnv("SALESFORCE_BROKER_ENABLED")
+	_ = viper.BindEnv("ADMIN_API_TOKEN")
 
 	// Gov.br OAuth2/PKCE
 	_ = viper.BindEnv("GOVBR_CLIENT_ID")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -81,6 +81,16 @@ type MetaConfig struct {
 	// Fail-closed: vazio/placeholder → endpoint sempre rejeita 401 (sem auth =
 	// sem outbound).
 	DispatchSecret string `mapstructure:"META_DISPATCH_SECRET"`
+	// FlowRegistry mapeia flow_name → service_name pra WhatsApp Flow inbound
+	// (`nfm_reply`). Espelha Property Mule `whatsapp.flow.registry`
+	// (ADR-024). Formato: `flow_name1:service_name1;flow_name2:service_name2`.
+	// Match é case-insensitive + substring-tolerante (ex: flow "Luminária
+	// Quebrada" casa com entry "luminaria"). Vazio = pular lookup,
+	// metadata.service_name = "defaultService" config.
+	FlowRegistry string `mapstructure:"META_FLOW_REGISTRY"`
+	// FlowDefaultService é o service_name fallback quando flow_name não bate
+	// nada no FlowRegistry. Match Mule `whatsapp.flow.defaultService`.
+	FlowDefaultService string `mapstructure:"META_FLOW_DEFAULT_SERVICE"`
 }
 
 type ServerConfig struct {
@@ -472,6 +482,8 @@ func bindEnvironmentVariables() {
 	_ = viper.BindEnv("META_GRAPH_API_VERSION")
 	_ = viper.BindEnv("META_SELF_CALLBACK_URL")
 	_ = viper.BindEnv("META_DISPATCH_SECRET")
+	_ = viper.BindEnv("META_FLOW_REGISTRY")
+	_ = viper.BindEnv("META_FLOW_DEFAULT_SERVICE")
 
 	// Core Application
 	_ = viper.BindEnv("APP_PREFIX")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -641,13 +641,9 @@ func bindEnvironmentVariables() {
 	_ = viper.BindEnv("CALLBACK_ALLOWED_DOMAIN")
 	_ = viper.BindEnv("CALLBACK_AUTH_TOKEN")
 
-	_ = viper.BindEnv("GOVBR_CLIENT_ID")
-	_ = viper.BindEnv("GOVBR_CLIENT_SECRET")
-	_ = viper.BindEnv("GOVBR_REDIRECT_URI")
-	_ = viper.BindEnv("GOVBR_AUTH_URL")
-	_ = viper.BindEnv("GOVBR_TOKEN_URL")
-	_ = viper.BindEnv("GOVBR_SCOPE")
-	_ = viper.BindEnv("GOVBR_AUTH_STATE_TTL")
+	// Gov.br OAuth2/PKCE — canonical list lives no bloco mais acima nessa função.
+	// (mantenha lá pra evitar drift; este placeholder existe só pra clareza
+	// quando alguém adicionar Callback envs novas e procurar onde pôr GOVBR.)
 
 	// Data Relay
 	_ = viper.BindEnv("DATA_RELAY_ENABLED")

--- a/internal/handlers/admin_broker_mode.go
+++ b/internal/handlers/admin_broker_mode.go
@@ -9,6 +9,7 @@
 package handlers
 
 import (
+	"crypto/sha256"
 	"crypto/subtle"
 	"net/http"
 	"time"
@@ -47,6 +48,15 @@ func NewAdminBrokerModeHandler(cfg *config.BrokerConfig, logger *logrus.Logger) 
 //	200 → {"salesforce_broker_enabled": true, "updated_at": "2026-05-22T..."}
 //	401 → token ausente/inválido (fail-closed)
 //	503 → endpoint sem token configurado (não habilitado neste deploy)
+//
+// Defesa em camadas contra timing attack:
+//  1. SHA256 dos dois operandos antes do compare — garante length-uniforme
+//     (subtle.ConstantTimeCompare retorna 0 imediatamente em length mismatch,
+//     leaking length do token expected). Atacante observando duração do
+//     handshake pode brute-force length antes do byte-by-byte ataque.
+//  2. subtle.ConstantTimeCompare sobre os hashes (sempre 32 bytes).
+//  3. Compare uniforme em TODOS os paths (incluindo header vazio) — sem
+//     early-return precoce que distinguia "missing" de "wrong".
 func (h *AdminBrokerModeHandler) HandleGet(c *gin.Context) {
 	if h.cfg.AdminAPIToken == "" || h.cfg.AdminAPIToken == "REPLACE_VIA_RUNTIME_MANAGER_PROPERTIES" {
 		h.logger.Warn("admin_broker_mode: ADMIN_API_TOKEN not configured; endpoint disabled")
@@ -54,14 +64,19 @@ func (h *AdminBrokerModeHandler) HandleGet(c *gin.Context) {
 		return
 	}
 	provided := c.GetHeader(adminTokenHeader)
-	if provided == "" {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "missing X-Admin-Token"})
-		return
-	}
-	if subtle.ConstantTimeCompare([]byte(provided), []byte(h.cfg.AdminAPIToken)) != 1 {
-		h.logger.WithField("event", "admin_broker_mode_unauthorized").
-			Warn("admin_broker_mode: token mismatch")
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid X-Admin-Token"})
+	providedHash := sha256.Sum256([]byte(provided))
+	expectedHash := sha256.Sum256([]byte(h.cfg.AdminAPIToken))
+	if subtle.ConstantTimeCompare(providedHash[:], expectedHash[:]) != 1 {
+		// Loga separadamente provided vazio (lib client desconfigurado) vs
+		// preenchido (provavelmente attempt malicioso); preserva observability
+		// sem reintroduzir o early-return de cima.
+		reason := "missing X-Admin-Token"
+		if provided != "" {
+			reason = "invalid X-Admin-Token"
+			h.logger.WithField("event", "admin_broker_mode_unauthorized").
+				Warn("admin_broker_mode: token mismatch")
+		}
+		c.JSON(http.StatusUnauthorized, gin.H{"error": reason})
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{

--- a/internal/handlers/admin_broker_mode.go
+++ b/internal/handlers/admin_broker_mode.go
@@ -1,0 +1,71 @@
+// Package handlers — admin endpoint /admin/broker-mode.
+//
+// Source of truth do master switch arquitetural Salesforce-broker vs Meta-direct:
+// env var SALESFORCE_BROKER_ENABLED (Infisical). Outras camadas (Mule) consultam
+// este endpoint a cada 30s pra propagação <1min sem redeploy.
+//
+// Auth via header X-Admin-Token comparado em constant-time com ADMIN_API_TOKEN.
+// Fail-closed: token vazio/placeholder → 401 sempre.
+package handlers
+
+import (
+	"crypto/subtle"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/sirupsen/logrus"
+
+	"github.com/prefeitura-rio/app-eai-agent-gateway/internal/config"
+)
+
+const adminTokenHeader = "X-Admin-Token"
+
+// AdminBrokerModeHandler — expõe GET /admin/broker-mode pra Mule pollar.
+type AdminBrokerModeHandler struct {
+	cfg    *config.BrokerConfig
+	logger *logrus.Logger
+	// startedAt fixa o tempo de boot do processo; updated_at no response
+	// é tempo de boot, pois flag é estática-por-pod (mudou no Infisical →
+	// pod restarta via Infisical agent → startedAt avança).
+	startedAt time.Time
+}
+
+// NewAdminBrokerModeHandler constrói o handler com config + logger.
+func NewAdminBrokerModeHandler(cfg *config.BrokerConfig, logger *logrus.Logger) *AdminBrokerModeHandler {
+	return &AdminBrokerModeHandler{
+		cfg:       cfg,
+		logger:    logger,
+		startedAt: time.Now().UTC(),
+	}
+}
+
+// HandleGet responde JSON com o estado atual da flag.
+//
+//	GET /admin/broker-mode
+//	Headers: X-Admin-Token: <ADMIN_API_TOKEN>
+//	200 → {"salesforce_broker_enabled": true, "updated_at": "2026-05-22T..."}
+//	401 → token ausente/inválido (fail-closed)
+//	503 → endpoint sem token configurado (não habilitado neste deploy)
+func (h *AdminBrokerModeHandler) HandleGet(c *gin.Context) {
+	if h.cfg.AdminAPIToken == "" || h.cfg.AdminAPIToken == "REPLACE_VIA_RUNTIME_MANAGER_PROPERTIES" {
+		h.logger.Warn("admin_broker_mode: ADMIN_API_TOKEN not configured; endpoint disabled")
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "admin endpoint not configured"})
+		return
+	}
+	provided := c.GetHeader(adminTokenHeader)
+	if provided == "" {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "missing X-Admin-Token"})
+		return
+	}
+	if subtle.ConstantTimeCompare([]byte(provided), []byte(h.cfg.AdminAPIToken)) != 1 {
+		h.logger.WithField("event", "admin_broker_mode_unauthorized").
+			Warn("admin_broker_mode: token mismatch")
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid X-Admin-Token"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"salesforce_broker_enabled": h.cfg.SalesforceBrokerEnabled,
+		"updated_at":                h.startedAt.Format(time.RFC3339),
+	})
+}

--- a/internal/handlers/admin_broker_mode_test.go
+++ b/internal/handlers/admin_broker_mode_test.go
@@ -128,3 +128,46 @@ func TestAdminBrokerMode_PlaceholderTokenReturns503(t *testing.T) {
 		t.Errorf("expected 503 (placeholder treated as unconfigured), got %d", w.Code)
 	}
 }
+
+func TestAdminBrokerMode_EmptyHeaderReturns401WithSpecificMessage(t *testing.T) {
+	// Constant-time path: header vazio cai no compare, retorna 401 com
+	// reason="missing X-Admin-Token" (vs "invalid X-Admin-Token" pra valor
+	// errado). Garante diferenciação semântica preservada pós-fix de timing leak.
+	h := newAdminHandler(t, config.BrokerConfig{
+		SalesforceBrokerEnabled: true,
+		AdminAPIToken:           "sec",
+	})
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/admin/broker-mode", nil)
+	// sem header (provided == "")
+	h.HandleGet(c)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+	var resp map[string]interface{}
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if got, _ := resp["error"].(string); got != "missing X-Admin-Token" {
+		t.Errorf("expected error=missing X-Admin-Token, got %q", got)
+	}
+}
+
+func TestAdminBrokerMode_WrongTokenReturns401WithSpecificMessage(t *testing.T) {
+	h := newAdminHandler(t, config.BrokerConfig{
+		SalesforceBrokerEnabled: true,
+		AdminAPIToken:           "sec",
+	})
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/admin/broker-mode", nil)
+	c.Request.Header.Set(adminTokenHeader, "wrong")
+	h.HandleGet(c)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+	var resp map[string]interface{}
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if got, _ := resp["error"].(string); got != "invalid X-Admin-Token" {
+		t.Errorf("expected error=invalid X-Admin-Token, got %q", got)
+	}
+}

--- a/internal/handlers/admin_broker_mode_test.go
+++ b/internal/handlers/admin_broker_mode_test.go
@@ -1,0 +1,130 @@
+package handlers
+
+import (
+	"encoding/json"
+	stdio "io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/sirupsen/logrus"
+
+	"github.com/prefeitura-rio/app-eai-agent-gateway/internal/config"
+)
+
+func newAdminHandler(t *testing.T, cfg config.BrokerConfig) *AdminBrokerModeHandler {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	logger := logrus.New()
+	logger.SetOutput(stdio.Discard)
+	return NewAdminBrokerModeHandler(&cfg, logger)
+}
+
+func TestAdminBrokerMode_HappyPath(t *testing.T) {
+	h := newAdminHandler(t, config.BrokerConfig{
+		SalesforceBrokerEnabled: true,
+		AdminAPIToken:           "sec",
+	})
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/admin/broker-mode", nil)
+	c.Request.Header.Set(adminTokenHeader, "sec")
+	h.HandleGet(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var resp map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+	if resp["salesforce_broker_enabled"] != true {
+		t.Errorf("expected true, got %v", resp["salesforce_broker_enabled"])
+	}
+	if resp["updated_at"] == "" {
+		t.Error("expected updated_at populated")
+	}
+}
+
+func TestAdminBrokerMode_FalseStateReturned(t *testing.T) {
+	h := newAdminHandler(t, config.BrokerConfig{
+		SalesforceBrokerEnabled: false,
+		AdminAPIToken:           "sec",
+	})
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/admin/broker-mode", nil)
+	c.Request.Header.Set(adminTokenHeader, "sec")
+	h.HandleGet(c)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var resp map[string]interface{}
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["salesforce_broker_enabled"] != false {
+		t.Errorf("expected false, got %v", resp["salesforce_broker_enabled"])
+	}
+}
+
+func TestAdminBrokerMode_MissingTokenReturns401(t *testing.T) {
+	h := newAdminHandler(t, config.BrokerConfig{
+		SalesforceBrokerEnabled: true,
+		AdminAPIToken:           "sec",
+	})
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/admin/broker-mode", nil)
+	// sem header
+	h.HandleGet(c)
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestAdminBrokerMode_WrongTokenReturns401(t *testing.T) {
+	h := newAdminHandler(t, config.BrokerConfig{
+		SalesforceBrokerEnabled: true,
+		AdminAPIToken:           "sec",
+	})
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/admin/broker-mode", nil)
+	c.Request.Header.Set(adminTokenHeader, "wrong")
+	h.HandleGet(c)
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestAdminBrokerMode_UnconfiguredTokenReturns503(t *testing.T) {
+	// Token vazio → endpoint não-configurado pra esse deploy. 503 (não 401)
+	// pra diferenciar "auth falhou" vs "feature off por config".
+	h := newAdminHandler(t, config.BrokerConfig{
+		SalesforceBrokerEnabled: true,
+		AdminAPIToken:           "",
+	})
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/admin/broker-mode", nil)
+	c.Request.Header.Set(adminTokenHeader, "anything")
+	h.HandleGet(c)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected 503, got %d", w.Code)
+	}
+}
+
+func TestAdminBrokerMode_PlaceholderTokenReturns503(t *testing.T) {
+	h := newAdminHandler(t, config.BrokerConfig{
+		SalesforceBrokerEnabled: true,
+		AdminAPIToken:           "REPLACE_VIA_RUNTIME_MANAGER_PROPERTIES",
+	})
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/admin/broker-mode", nil)
+	c.Request.Header.Set(adminTokenHeader, "REPLACE_VIA_RUNTIME_MANAGER_PROPERTIES")
+	h.HandleGet(c)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected 503 (placeholder treated as unconfigured), got %d", w.Code)
+	}
+}

--- a/internal/handlers/flow_registry.go
+++ b/internal/handlers/flow_registry.go
@@ -1,0 +1,115 @@
+// Package handlers — WhatsApp Flow registry (flow_name → service_name).
+//
+// Mirror Mule `whatsapp.flow.registry` (ADR-024). Quando cidadão submete
+// um WhatsApp Flow (`interactive.nfm_reply`), MetaWebhookHandler:
+//
+//  1. Extrai flow_name + response_json do payload
+//  2. Resolve service_name via FlowRegistry (substring-tolerante,
+//     case-insensitive). Default fallback se nenhum bater.
+//  3. Inclui `service_name` + `form_submission` (estruturado, parseado
+//     do response_json) em `metadata` pro Engine rotear pra handler correto.
+//
+// Adicionar Flow novo = adicionar entry no registry via env var
+// (META_FLOW_REGISTRY="flow1:service1;flow2:service2"). Sem redeploy.
+package handlers
+
+import (
+	"encoding/json"
+	"strings"
+	"unicode"
+
+	"golang.org/x/text/runes"
+	"golang.org/x/text/transform"
+	"golang.org/x/text/unicode/norm"
+)
+
+// stripDiacritics remove acentos pra match insensitive a diacritico.
+// "Luminária Quebrada" → "Luminaria Quebrada". Falha de transform retorna
+// input cru (best-effort).
+func stripDiacritics(s string) string {
+	t := transform.Chain(norm.NFD, runes.Remove(runes.In(unicode.Mn)), norm.NFC)
+	res, _, err := transform.String(t, s)
+	if err != nil {
+		return s
+	}
+	return res
+}
+
+// normalizeForMatch — lowercase + strip diacritics. Usado em ambos os lados
+// (entry no registry e flow_name do Meta) pra match robusto.
+func normalizeForMatch(s string) string {
+	return stripDiacritics(strings.ToLower(strings.TrimSpace(s)))
+}
+
+// FlowRegistry resolve flow_name → service_name. Imutável após NewFlowRegistry.
+type FlowRegistry struct {
+	entries        []flowEntry
+	defaultService string
+}
+
+type flowEntry struct {
+	flowNameNormalized string // lowercase + sem diacritico
+	serviceName        string
+}
+
+// NewFlowRegistry parseia a config-string e constrói o lookup. Formato:
+// "flow_name_1:service_1;flow_name_2:service_2" (semicolon-separated,
+// colon-separated). Whitespace é trimmed. Entries malformadas (sem `:`)
+// são ignoradas silenciosamente.
+func NewFlowRegistry(config, defaultService string) *FlowRegistry {
+	r := &FlowRegistry{defaultService: defaultService}
+	for _, part := range strings.Split(config, ";") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		colon := strings.IndexByte(part, ':')
+		if colon <= 0 || colon == len(part)-1 {
+			continue
+		}
+		flow := strings.TrimSpace(part[:colon])
+		service := strings.TrimSpace(part[colon+1:])
+		if flow == "" || service == "" {
+			continue
+		}
+		r.entries = append(r.entries, flowEntry{
+			flowNameNormalized: normalizeForMatch(flow),
+			serviceName:        service,
+		})
+	}
+	return r
+}
+
+// Resolve retorna o service_name pra um flow_name. Match em ordem:
+//  1. substring case-insensitive + diacritic-insensitive (registry entry
+//     "luminaria" bate flow_name "Luminária Quebrada"). Primeiro match wins.
+//  2. defaultService se nada bater.
+//  3. "" se default também vazio.
+func (r *FlowRegistry) Resolve(flowName string) string {
+	if r == nil {
+		return ""
+	}
+	target := normalizeForMatch(flowName)
+	if target != "" {
+		for _, e := range r.entries {
+			if strings.Contains(target, e.flowNameNormalized) {
+				return e.serviceName
+			}
+		}
+	}
+	return r.defaultService
+}
+
+// ParseFlowResponse parse o `response_json` (string JSON enviada pela
+// Meta no nfm_reply.response_json) em map estruturado. Retorna nil em
+// erros de parsing — caller cai pra propagar o raw.
+func ParseFlowResponse(responseJSON string) map[string]interface{} {
+	if responseJSON == "" {
+		return nil
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal([]byte(responseJSON), &m); err != nil {
+		return nil
+	}
+	return m
+}

--- a/internal/handlers/flow_registry.go
+++ b/internal/handlers/flow_registry.go
@@ -15,6 +15,7 @@ package handlers
 
 import (
 	"encoding/json"
+	"sort"
 	"strings"
 	"unicode"
 
@@ -77,12 +78,23 @@ func NewFlowRegistry(config, defaultService string) *FlowRegistry {
 			serviceName:        service,
 		})
 	}
+	// Ordena longest-first pra resolver match por especificidade, não por
+	// ordem de declaração. Sem isso, registry "luz:eletrica;luminaria:reparo"
+	// com flow_name "Luminária Quebrada" casaria "luz" primeiro (substring),
+	// retornando "eletrica" em vez de "reparo". Risco operacional invisível
+	// pro operador setando o registry. Longest-first elimina a armadilha:
+	// entries mais específicas (mais longas) sempre ganham.
+	sort.SliceStable(r.entries, func(i, j int) bool {
+		return len(r.entries[i].flowNameNormalized) > len(r.entries[j].flowNameNormalized)
+	})
 	return r
 }
 
 // Resolve retorna o service_name pra um flow_name. Match em ordem:
-//  1. substring case-insensitive + diacritic-insensitive (registry entry
-//     "luminaria" bate flow_name "Luminária Quebrada"). Primeiro match wins.
+//  1. substring case-insensitive + diacritic-insensitive, ENTRIES ORDENADAS
+//     LONGEST-FIRST. Entry "luminaria" bate flow_name "Luminária Quebrada".
+//     Longest-first garante que registry "luz:X;luminaria:Y" resolve
+//     "Luminária Quebrada" pra "Y" (não pra "X") — match por especificidade.
 //  2. defaultService se nada bater.
 //  3. "" se default também vazio.
 func (r *FlowRegistry) Resolve(flowName string) string {

--- a/internal/handlers/flow_registry_test.go
+++ b/internal/handlers/flow_registry_test.go
@@ -1,0 +1,70 @@
+package handlers
+
+import "testing"
+
+func TestFlowRegistry_LongestFirstWins(t *testing.T) {
+	// Armadilha histórica: substring match retornava first-declared. Com
+	// registry "luz:eletrica;luminaria:reparo", flow_name "Luminária Quebrada"
+	// casava "luz" primeiro → service errado. Longest-first resolve por
+	// especificidade independente da ordem do operador.
+	cases := []struct {
+		name           string
+		config         string
+		flowName       string
+		expectedSvc    string
+	}{
+		{
+			name:        "longest entry wins independent of declaration order",
+			config:      "luz:eletrica;luminaria:reparo_luminaria",
+			flowName:    "Luminária Quebrada",
+			expectedSvc: "reparo_luminaria",
+		},
+		{
+			name:        "reverse declaration order — still longest wins",
+			config:      "luminaria:reparo_luminaria;luz:eletrica",
+			flowName:    "Luminária Quebrada",
+			expectedSvc: "reparo_luminaria",
+		},
+		{
+			name:        "diacritic + case insensitive match",
+			config:      "luminaria:reparo",
+			flowName:    "LUMINÁRIA",
+			expectedSvc: "reparo",
+		},
+		{
+			name:        "short entry still wins when only it matches",
+			config:      "luz:eletrica;agua:saneamento",
+			flowName:    "Luz da Rua",
+			expectedSvc: "eletrica",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := NewFlowRegistry(tc.config, "fallback_svc")
+			if got := r.Resolve(tc.flowName); got != tc.expectedSvc {
+				t.Errorf("got %q, want %q", got, tc.expectedSvc)
+			}
+		})
+	}
+}
+
+func TestFlowRegistry_DefaultWhenNothingMatches(t *testing.T) {
+	r := NewFlowRegistry("luz:eletrica", "default_svc")
+	if got := r.Resolve("Outra coisa qualquer"); got != "default_svc" {
+		t.Errorf("got %q, want default_svc", got)
+	}
+}
+
+func TestFlowRegistry_EmptyFlowNameReturnsDefault(t *testing.T) {
+	r := NewFlowRegistry("luz:eletrica", "default_svc")
+	if got := r.Resolve(""); got != "default_svc" {
+		t.Errorf("expected default on empty flow_name, got %q", got)
+	}
+}
+
+func TestFlowRegistry_NilSafe(t *testing.T) {
+	var r *FlowRegistry
+	if got := r.Resolve("anything"); got != "" {
+		t.Errorf("nil receiver should return empty, got %q", got)
+	}
+}

--- a/internal/handlers/govbr_callback.go
+++ b/internal/handlers/govbr_callback.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -14,6 +15,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/prefeitura-rio/app-eai-agent-gateway/internal/config"
+	"github.com/prefeitura-rio/app-eai-agent-gateway/internal/services"
 )
 
 // GovBrCallbackHandler handles Gov.br OAuth2/PKCE callback
@@ -103,15 +105,26 @@ func (h *GovBrCallbackHandler) HandleCallback(c *gin.Context) {
 		return
 	}
 
-	// 3. Retrieve auth state from Redis
+	// 3. Retrieve auth state from Redis. Discriminar TTL/evict (`expired`)
+	// vs Redis down (`internal_error`) — sem isso, cidadão vê "sessão
+	// expirada" mesmo quando o erro real é Redis indisponível, ofuscando
+	// a causa raiz na hora da incidência.
 	redisKey := fmt.Sprintf("govbr_auth:%s", authID)
 	authStateJSON, err := h.redisService.Get(ctx, redisKey)
 	if err != nil {
-		logger.WithError(err).Error("Auth state not found or expired in Redis")
-		c.HTML(http.StatusBadRequest, "govbr_auth_error.html", gin.H{
-			"error": "expired_request",
-			"description": "Sessão de autenticação expirada. " +
-				"Por favor, retorne ao WhatsApp e inicie o processo novamente.",
+		if errors.Is(err, services.ErrKeyNotFound) {
+			logger.Warn("govbr_callback: auth state not found (expired/invalid state)")
+			c.HTML(http.StatusBadRequest, "govbr_auth_error.html", gin.H{
+				"error": "expired_request",
+				"description": "Sessão de autenticação expirada. " +
+					"Por favor, retorne ao WhatsApp e inicie o processo novamente.",
+			})
+			return
+		}
+		logger.WithError(err).Error("govbr_callback: Redis lookup failed (transient)")
+		c.HTML(http.StatusServiceUnavailable, "govbr_auth_error.html", gin.H{
+			"error":       "internal_error",
+			"description": "Erro interno ao validar sessão. Por favor, tente novamente em instantes.",
 		})
 		return
 	}
@@ -164,9 +177,18 @@ func (h *GovBrCallbackHandler) HandleCallback(c *gin.Context) {
 
 	// 6. Update auth state to "completed"
 	authState.State = "completed"
-	updatedStateJSON, _ := json.Marshal(authState)
-	// Keep state for a bit longer for audit/debugging
-	h.redisService.Set(ctx, redisKey, string(updatedStateJSON), 5*time.Minute)
+	updatedStateJSON, marshalErr := json.Marshal(authState)
+	if marshalErr != nil {
+		// Audit-only failure (tokens já foram persistidos no passo 5); loga
+		// Warn pra rastreabilidade mas NÃO falha a request — cidadão vê
+		// sucesso e o flow continua.
+		logger.WithError(marshalErr).Warn("govbr_callback: failed to marshal updated auth state (audit-only)")
+	} else if setErr := h.redisService.Set(ctx, redisKey, string(updatedStateJSON), 5*time.Minute); setErr != nil {
+		// Mesmo race-free: tokens já foram salvos. Sem o Warn aqui o erro
+		// ficava completamente silencioso, removendo trail de audit pra
+		// debugar uma incidência futura.
+		logger.WithError(setErr).Warn("govbr_callback: failed to update auth state to completed (audit-only)")
+	}
 
 	logger.Info("Gov.br authentication completed successfully")
 

--- a/internal/handlers/govbr_initiate.go
+++ b/internal/handlers/govbr_initiate.go
@@ -42,8 +42,13 @@ func (h *GovBrCallbackHandler) HandleInitiate(c *gin.Context) {
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "initiate secret not configured"})
 		return
 	}
+	// SHA256 ambos antes de subtle.ConstantTimeCompare: length-uniforme evita
+	// timing leak via length mismatch (ConstantTimeCompare retorna 0 imediato
+	// se lens diferem). Hashing aplaina pra 32 bytes em todos os casos.
 	provided := c.GetHeader(govBrInitiateSecretHeader)
-	if provided == "" || subtle.ConstantTimeCompare([]byte(provided), []byte(expected)) != 1 {
+	providedHash := sha256.Sum256([]byte(provided))
+	expectedHash := sha256.Sum256([]byte(expected))
+	if subtle.ConstantTimeCompare(providedHash[:], expectedHash[:]) != 1 {
 		h.logger.WithField("event", "govbr_initiate_unauthorized").Warn("govbr_initiate: missing/invalid secret header")
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
 		return

--- a/internal/handlers/message.go
+++ b/internal/handlers/message.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -846,14 +847,31 @@ func validateCallbackURL(callbackURL string) error {
 		return fmt.Errorf("callback URL must use HTTP or HTTPS protocol")
 	}
 
-	// Check for localhost and private IP addresses
+	// Check for localhost (string-form). IP-form loopback ("127.0.0.1", "::1",
+	// "::ffff:127.0.0.1", "::ffff:7f00:1") é coberto pelo `IsLoopback()` no
+	// bloco abaixo — string-equality cobre só o caso "localhost" (DNS).
 	host := parsedURL.Hostname()
-	if host == "localhost" || host == "127.0.0.1" || host == "::1" {
+	if strings.EqualFold(host, "localhost") {
 		return fmt.Errorf("callback URL cannot use localhost")
 	}
 
-	// Check if host is an IP address and if it's private
-	if ip := net.ParseIP(host); ip != nil {
+	// Strip IPv6 zone index ("fe80::1%eth0" → "fe80::1") antes do parse —
+	// net.ParseIP retorna nil em string com zone. Sem stripping, atacante
+	// pode bypass via `http://[::1%25lo0]/` (URL-encoded %25 vira %) que o
+	// Go http.Client resolve pra IPv6 loopback via zone lo0. Hostname() já
+	// devolve sem `%25`, então só temos que tratar o `%` literal.
+	ipStr := host
+	if i := strings.IndexByte(host, '%'); i >= 0 {
+		ipStr = host[:i]
+	}
+	// Check if host is an IP address. Tratamento robusto a IPv4-mapped IPv6
+	// (`::ffff:127.0.0.1`, `::ffff:10.0.0.1`) — net.ParseIP normaliza pra
+	// IPv4 atrás, mas string match em "127.0.0.1" não captura.
+	// IsLoopback/IsUnspecified/IsPrivate cobrem todas as formas.
+	if ip := net.ParseIP(ipStr); ip != nil {
+		if ip.IsLoopback() || ip.IsUnspecified() || ip.IsLinkLocalUnicast() {
+			return fmt.Errorf("callback URL cannot use loopback, unspecified, or link-local IP")
+		}
 		if isPrivateIP(ip) {
 			return fmt.Errorf("callback URL cannot use private IP addresses")
 		}
@@ -862,8 +880,17 @@ func validateCallbackURL(callbackURL string) error {
 	return nil
 }
 
-// isPrivateIP checks if an IP address is in a private range
+// isPrivateIP checks if an IP address is in a private range.
+//
+// Normaliza IPv4-mapped IPv6 (`::ffff:a.b.c.d`) antes do match — sem isso,
+// atacante poderia bypass via `http://[::ffff:10.0.0.1]/...` (Go transport
+// resolve pro IPv4 atrás, mas o CIDR match em `10.0.0.0/8` falha porque
+// `network.Contains(::ffff:10.0.0.1)` retorna false). Stdlib `net.IP.To4()`
+// devolve o IPv4 puro se disponível; caso contrário mantém o IPv6 original.
 func isPrivateIP(ip net.IP) bool {
+	if v4 := ip.To4(); v4 != nil {
+		ip = v4
+	}
 	privateRanges := []string{
 		"10.0.0.0/8",
 		"172.16.0.0/12",

--- a/internal/handlers/message.go
+++ b/internal/handlers/message.go
@@ -76,6 +76,207 @@ func NewMessageHandler(
 	}
 }
 
+// EnqueueResult contains the outcome of enqueueing a user message.
+// Returned by EnqueueUserMessage so non-HTTP callers (e.g. MetaWebhookHandler)
+// can decide their own response shape without going through gin.Context.
+type EnqueueResult struct {
+	MessageID string
+	Status    string
+}
+
+// EnqueueOptions controla privilégios do caller. `TrustedInternal=true` é usado
+// por entrypoints confiáveis (Meta-direct webhook) que precisam apontar pro
+// SelfCallbackURL reservado. Callers externos (`/api/v1/message/webhook/user`)
+// passam false: tentar apontar pro SelfCallbackURL é rejeitado como inválido.
+type EnqueueOptions struct {
+	TrustedInternal bool
+}
+
+// EnqueueUserMessage é o core enqueue path compartilhado por HTTP handler e
+// entrypoints alternos (Meta-direct webhook).
+//
+// Errors:
+//   - ErrInvalidPayload (400-class): payload semantics violated
+//     (missing content, bad message_type, bad callback URL, attempted use
+//     of reserved internal callback URL)
+//   - other errors são 500-class (Redis/RabbitMQ down)
+//
+// Caller provê `req` já JSON-decoded + minimal metadata (request_id,
+// trace headers if any). Não toca gin.Context — pure business logic.
+func (h *MessageHandler) EnqueueUserMessage(
+	ctx context.Context,
+	req *models.UserWebhookRequest,
+	requestID string,
+	traceHeaders map[string]interface{},
+	opts EnqueueOptions,
+) (*EnqueueResult, error) {
+	if req == nil {
+		return nil, ErrInvalidPayload{Reason: "nil request"}
+	}
+	if req.UserNumber == "" {
+		return nil, ErrInvalidPayload{Reason: "user_number is required"}
+	}
+
+	if req.MessageType != nil && *req.MessageType != "" {
+		mt := *req.MessageType
+		valid := map[string]bool{
+			"text": true, "image": true, "audio": true, "video": true,
+			"location": true, "unsupported": true, "unknown": true,
+		}
+		if !valid[mt] {
+			return nil, ErrInvalidPayload{Reason: "message_type must be one of: text, image, audio, video, location, unsupported, unknown"}
+		}
+	}
+
+	hasText := req.Message != ""
+	noMediaTypesAllowed := req.MessageType != nil &&
+		(*req.MessageType == "unsupported" || *req.MessageType == "unknown")
+	hasMedia := req.MessageType != nil && *req.MessageType != "" && *req.MessageType != "text" &&
+		(len(req.Media) > 0 || noMediaTypesAllowed)
+	if !hasText && !hasMedia {
+		return nil, ErrInvalidPayload{Reason: "either `message` (non-empty) OR (`message_type` != \"text\" AND `media`) is required"}
+	}
+
+	if req.CallbackURL != nil && *req.CallbackURL != "" {
+		if err := validateCallbackURL(*req.CallbackURL); err != nil {
+			return nil, ErrInvalidPayload{Reason: "invalid callback URL: " + err.Error()}
+		}
+		// Reservar SelfCallbackURL pra uso interno (Meta-direct). Callers
+		// externos do `/api/v1/message/webhook/user` apontando pra SelfCallbackURL
+		// receberiam resposta autenticada do `/meta/dispatch` e poderiam disparar
+		// SendText ao próprio user_number via Meta credentials. MetaWebhookHandler
+		// passa `opts.TrustedInternal=true` pra bypass; outros são rejeitados.
+		if !opts.TrustedInternal &&
+			h.config.Meta.SelfCallbackURL != "" &&
+			*req.CallbackURL == h.config.Meta.SelfCallbackURL {
+			return nil, ErrInvalidPayload{Reason: "callback URL reserved for internal Meta-direct path"}
+		}
+	}
+
+	messageID := models.GenerateMessageID()
+	provider := "google_agent_engine"
+	if req.Provider != nil && *req.Provider != "" {
+		provider = *req.Provider
+	}
+
+	logger := h.logger.WithFields(logrus.Fields{
+		"message_id":  messageID,
+		"user_number": req.UserNumber,
+		"provider":    provider,
+	})
+
+	ctxTimeout, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	if err := h.redisService.SetTaskStatus(ctxTimeout, messageID, string(models.TaskStatusProcessing), h.config.Redis.TaskStatusTTL); err != nil {
+		logger.WithError(err).Error("Failed to set initial task status")
+		return nil, fmt.Errorf("set task status: %w", err)
+	}
+
+	queueMessage := models.QueueMessage{
+		ID:                messageID,
+		Type:              "user_message",
+		UserNumber:        req.UserNumber,
+		Message:           req.Message,
+		PreviousMessage:   req.PreviousMessage,
+		Provider:          provider,
+		Timestamp:         time.Now(),
+		Metadata:          req.Metadata,
+		ReasoningEngineID: req.ReasoningEngineID,
+		MessageType:       req.MessageType,
+		Media:             req.Media,
+	}
+	if queueMessage.Metadata == nil {
+		queueMessage.Metadata = make(map[string]interface{})
+	}
+	if requestID != "" {
+		queueMessage.Metadata["request_id"] = requestID
+	}
+	if _, ok := queueMessage.Metadata["source"]; !ok {
+		queueMessage.Metadata["source"] = "webhook"
+	}
+
+	// Quando CallbackURL está setado (Meta-direct ou caller que precisa de
+	// push), as duas escritas Redis abaixo são DELIVERY-CRITICAL:
+	//   - `task:metadata:*` é como o callback handler (e.g. /meta/dispatch)
+	//     recupera user_number pra mandar a resposta.
+	//   - `StoreCallbackURL` é como o worker descobre que precisa fazer push.
+	// Falha silenciosa aqui = HandleInbound retorna 200 a Meta, Meta para
+	// de retentar, e cidadão nunca recebe resposta. Pra modo callback,
+	// erro nessas escritas vira erro fatal de enqueue.
+	hasCallback := req.CallbackURL != nil && *req.CallbackURL != ""
+	// TTL pra callback-backed messages: precisa cobrir o pior caso de
+	// worker runtime (Google Agent Engine pode rodar ~30min) + retry window.
+	// TaskStatusTTL default (10min) é insuficiente. Usar o maior entre
+	// TaskStatusTTL configurado e 1h.
+	ttl := h.config.Redis.TaskStatusTTL
+	if hasCallback {
+		const minCallbackTTL = 1 * time.Hour
+		if ttl < minCallbackTTL {
+			ttl = minCallbackTTL
+		}
+	}
+
+	metadataForResponse := map[string]interface{}{
+		"user_number": req.UserNumber,
+		"provider":    provider,
+	}
+	metadataBytes, err := json.Marshal(metadataForResponse)
+	if err != nil {
+		return nil, fmt.Errorf("marshal metadata: %w", err)
+	}
+	metadataKey := "task:metadata:" + messageID
+	if err := h.redisService.Set(ctxTimeout, metadataKey, string(metadataBytes), ttl); err != nil {
+		if hasCallback {
+			logger.WithError(err).Error("Failed to store task metadata; aborting (callback path requires it)")
+			return nil, fmt.Errorf("store task metadata: %w", err)
+		}
+		logger.WithError(err).Warn("Failed to store task metadata, continuing (polling-only path)")
+	}
+
+	if hasCallback {
+		if err := h.redisService.StoreCallbackURL(ctxTimeout, messageID, *req.CallbackURL, ttl); err != nil {
+			logger.WithError(err).Error("Failed to store callback URL; aborting enqueue (would silent-drop)")
+			return nil, fmt.Errorf("store callback url: %w", err)
+		}
+	}
+
+	var pubErr error
+	if traceHeaders != nil && h.rabbitMQService != nil {
+		if publisherWithHeaders, ok := h.rabbitMQService.(interface {
+			PublishMessageWithHeaders(ctx context.Context, queueName string, message interface{}, headers map[string]interface{}) error
+		}); ok {
+			pubErr = publisherWithHeaders.PublishMessageWithHeaders(ctxTimeout, h.config.RabbitMQ.UserMessagesQueue, queueMessage, traceHeaders)
+		} else {
+			pubErr = h.rabbitMQService.PublishMessage(ctxTimeout, h.config.RabbitMQ.UserMessagesQueue, queueMessage)
+		}
+	} else {
+		pubErr = h.rabbitMQService.PublishMessage(ctxTimeout, h.config.RabbitMQ.UserMessagesQueue, queueMessage)
+	}
+
+	if pubErr != nil {
+		logger.WithError(pubErr).Error("Failed to queue user message")
+		_ = h.redisService.SetTaskStatus(ctxTimeout, messageID, string(models.TaskStatusFailed), h.config.Redis.TaskStatusTTL)
+		return nil, fmt.Errorf("publish queue: %w", pubErr)
+	}
+
+	logger.Info("User message queued successfully")
+	return &EnqueueResult{
+		MessageID: messageID,
+		Status:    string(models.TaskStatusProcessing),
+	}, nil
+}
+
+// ErrInvalidPayload é um erro 400-class retornado por EnqueueUserMessage
+// quando o payload viola contrato (campos faltando, valores inválidos).
+type ErrInvalidPayload struct {
+	Reason string
+}
+
+func (e ErrInvalidPayload) Error() string {
+	return e.Reason
+}
+
 // HandleUserWebhook processes user messages and queues them for processing
 //
 //	@Summary		Process user message webhook
@@ -149,6 +350,18 @@ func (h *MessageHandler) HandleUserWebhook(c *gin.Context) {
 			c.JSON(http.StatusBadRequest, gin.H{
 				"error":   "Invalid callback URL",
 				"message": err.Error(),
+			})
+			return
+		}
+		// Reservar SelfCallbackURL pra path Meta-direct interno. External
+		// callers que tentam fingir Meta-direct receberiam resposta autenticada
+		// no `/meta/dispatch` e poderiam disparar SendText arbitrário ao
+		// próprio user_number via Meta credentials.
+		if h.config.Meta.SelfCallbackURL != "" && *req.CallbackURL == h.config.Meta.SelfCallbackURL {
+			h.logger.WithField("callback_url", *req.CallbackURL).Warn("Rejected external use of internal Meta-direct callback URL")
+			c.JSON(http.StatusBadRequest, gin.H{
+				"error":   "Invalid callback URL",
+				"message": "callback URL reserved for internal Meta-direct path",
 			})
 			return
 		}

--- a/internal/handlers/message_test.go
+++ b/internal/handlers/message_test.go
@@ -1,0 +1,123 @@
+package handlers
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestValidateCallbackURL_RejectsLoopbackVariants verifies that string-form
+// loopback (`localhost`) and IP-form loopback (incluindo IPv4-mapped IPv6
+// `::ffff:127.0.0.1` e short-form `::ffff:7f00:1`) são bloqueados. SEM o fix
+// do isPrivateIP/IsLoopback, atacante poderia bypass com IPv4-mapped IPv6
+// encoding pra atingir loopback via Go HTTP transport (que resolve atrás).
+func TestValidateCallbackURL_RejectsLoopbackVariants(t *testing.T) {
+	loopbackURLs := []string{
+		"http://localhost/path",
+		"http://LOCALHOST/path",            // case-insensitive DNS
+		"http://127.0.0.1/path",            // IPv4 form
+		"http://[::1]/path",                // IPv6 form
+		"http://[::ffff:127.0.0.1]/path",   // IPv4-mapped IPv6 (long form)
+		"http://[::ffff:7f00:1]/path",      // IPv4-mapped IPv6 (compact hex form)
+		"http://[::ffff:127.0.0.1]:80/path",
+	}
+	for _, u := range loopbackURLs {
+		t.Run(u, func(t *testing.T) {
+			err := validateCallbackURL(u)
+			if err == nil {
+				t.Fatalf("expected validation error for %q, got nil", u)
+			}
+			// Mensagem mais robusta — não checa string específica pra resistir a
+			// refactor; só checa que callback foi bloqueado.
+			if !strings.Contains(err.Error(), "loopback") && !strings.Contains(err.Error(), "localhost") {
+				t.Errorf("expected loopback/localhost rejection, got %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateCallbackURL_RejectsPrivateIPVariants(t *testing.T) {
+	// IPv4 puro + IPv4-mapped IPv6 devem ambos bater no CIDR match — sem o
+	// `ip.To4()` antes do match, o CIDR `10.0.0.0/8` não contém o IPv6.
+	privateURLs := []string{
+		"http://10.0.0.1/x",
+		"http://[::ffff:10.0.0.1]/x",
+		"http://172.16.0.1/x",
+		"http://[::ffff:172.16.0.1]/x",
+		"http://192.168.1.1/x",
+		"http://[::ffff:192.168.1.1]/x",
+		"http://169.254.169.254/x", // AWS metadata (link-local)
+		"http://[::ffff:169.254.169.254]/x",
+	}
+	for _, u := range privateURLs {
+		t.Run(u, func(t *testing.T) {
+			err := validateCallbackURL(u)
+			if err == nil {
+				t.Fatalf("expected private IP rejection for %q, got nil", u)
+			}
+		})
+	}
+}
+
+func TestValidateCallbackURL_AcceptsPublic(t *testing.T) {
+	publicURLs := []string{
+		"https://api.example.com/webhook",
+		"https://gateway.staging.prefeitura.rio/api",
+		"http://[2001:db8::1]/x", // Public IPv6 (documentation range; not in private list)
+	}
+	for _, u := range publicURLs {
+		t.Run(u, func(t *testing.T) {
+			if err := validateCallbackURL(u); err != nil {
+				t.Errorf("expected valid URL %q, got error %v", u, err)
+			}
+		})
+	}
+}
+
+func TestValidateCallbackURL_RejectsBadScheme(t *testing.T) {
+	badURLs := []string{
+		"file:///etc/passwd",
+		"ftp://example.com/x",
+		"gopher://example.com/x",
+		"ws://example.com/x",
+	}
+	for _, u := range badURLs {
+		t.Run(u, func(t *testing.T) {
+			if err := validateCallbackURL(u); err == nil {
+				t.Errorf("expected scheme rejection for %q, got nil", u)
+			}
+		})
+	}
+}
+
+func TestValidateCallbackURL_RejectsOversized(t *testing.T) {
+	// Limite explícito em 2048; payload acima deve falhar com mensagem clara.
+	longURL := "https://example.com/" + strings.Repeat("a", 3000)
+	err := validateCallbackURL(longURL)
+	if err == nil {
+		t.Fatal("expected oversized URL rejection, got nil")
+	}
+	if !strings.Contains(err.Error(), "maximum length") {
+		t.Errorf("expected length rejection message, got %v", err)
+	}
+}
+
+func TestValidateCallbackURL_RejectsZoneIndexedAndLinkLocalIPv6(t *testing.T) {
+	// IPv6 zone index (URL-encoded %25 vira % no Hostname). net.ParseIP
+	// retorna nil pra string com zone — SEM o strip, atacante bypassa o
+	// check e Go http.Client resolve via zone lo0. Strip do %... antes do
+	// parse + ip.IsLinkLocalUnicast() pra fe80::/10 cobre o gap.
+	rejectedURLs := []string{
+		"http://[::1%25lo0]/x",            // zone-indexed loopback
+		"http://[fe80::1%25eth0]/x",        // zone-indexed link-local
+		"http://[fe80::1]/x",               // raw link-local (no zone)
+		"http://169.254.0.1/x",             // IPv4 link-local (covered by private)
+	}
+	for _, u := range rejectedURLs {
+		t.Run(u, func(t *testing.T) {
+			err := validateCallbackURL(u)
+			if err == nil {
+				t.Errorf("expected zone/link-local rejection for %q, got nil", u)
+			}
+		})
+	}
+}

--- a/internal/handlers/meta_dedup_consts.go
+++ b/internal/handlers/meta_dedup_consts.go
@@ -1,0 +1,44 @@
+// Package handlers — constantes de dedup compartilhadas entre
+// meta_webhook.go (inbound, key `meta:wamid:<wamid>`) e meta_dispatch.go
+// (outbound, key `meta:dispatch:sent:<message_id>`).
+//
+// Os dois keyspaces são distintos mas usam o mesmo conjunto de sentinelas
+// pra value das chaves — agrupados aqui pra evitar cross-file coupling
+// implícito (constante definida num arquivo e usada noutro sem doc).
+//
+// TTL nominal de 24h em ambos: bate com o máximo de uma session window
+// do WhatsApp Business; suficiente pra absorver Meta retry aggressive
+// (primeiros minutos pós-envio) sem reter histórico indefinido.
+package handlers
+
+import "time"
+
+// dedupTTL — TTL de claim em ambos os keyspaces.
+//
+// Inbound (`meta:wamid:<wamid>`): claim marca wamid como "já processado"
+// pra dedup de Meta retries.
+// Outbound (`meta:dispatch:sent:<message_id>`): claim marca message_id
+// como "já dispatchado" pra dedup de worker retries pós-callback.
+const dedupTTL = 24 * time.Hour
+
+// dispatchSentMarkerTTL — alias semântico de dedupTTL no contexto outbound.
+// Mantido separado pro caso de divergir no futuro (ex: outbound poder ter
+// TTL mais curto se idempotência de wamid via Meta API for confiável).
+const dispatchSentMarkerTTL = 24 * time.Hour
+
+// Sentinelas pra value das claims. Definição centralizada porque
+// `dedupValueNoContent` é escrito por meta_dispatch.go mas lido nos testes
+// e referenciado nos comentários de meta_webhook.go — declarar onde é
+// escrito (dispatch) deixava o read-site sem visibilidade do conjunto
+// completo de estados possíveis.
+const (
+	// dedupValueInflight — claim ativa, processamento em curso. Concurrent
+	// retries veem este valor e recebem 503 (Meta retenta).
+	dedupValueInflight = "inflight"
+	// dedupValueDone — inbound completou enqueue. Duplicatas viram 200.
+	dedupValueDone = "done"
+	// dedupValueNoContent — outbound decidiu não enviar (callback sem
+	// texto nem media envelope). Sentinela terminal; concurrent retries
+	// veem "already_sent" em vez de 503, evitando ficar presos 24h.
+	dedupValueNoContent = "no_content"
+)

--- a/internal/handlers/meta_dispatch.go
+++ b/internal/handlers/meta_dispatch.go
@@ -163,9 +163,18 @@ func (h *MetaDispatchHandler) HandleDispatch(c *gin.Context) {
 	//     Concurrent retries veem isso e retornam 503 (worker retenta após).
 	//   - "<wamid>": SendText completou. Concurrent retries retornam 200 sem
 	//     reenviar (idempotência efetiva).
+	//   - "done": fallback terminal quando Set(wamid) falha pós-send OK.
+	//   - "no_content": payload sem texto nem media — terminal.
 	//   - missing: ninguém tentou ainda; claim com SetNX.
 	//
 	// Sem SETNX (claimer nil), cai pra Get+Set best-effort (vulnerável a race).
+	//
+	// ORDEM: claim ANTES do metadata lookup é intencional. Inverter (lookup
+	// primeiro) abriria janela onde 2 workers concorrentes ambos passam pelo
+	// Get OK + ambos fazem SendText → duplicate ao cidadão. Trade-off: se o
+	// metadata expirou (404), o sentKey fica "inflight" até o defer liberar
+	// (~µs); concurrent retry nesse intervalo vê inflight e retorna 503, é OK
+	// porque vai retentar próximo round.
 	sentKey := "meta:dispatch:sent:" + payload.MessageID
 	// success default-false: defer libera claim em qualquer return early
 	// (failure path SendText, panic, etc.). Apenas paths que PRESERVAM
@@ -211,7 +220,18 @@ func (h *MetaDispatchHandler) HandleDispatch(c *gin.Context) {
 		}()
 	} else {
 		// Fallback non-atomic: Get + Set. Vulnerável a race em concurrent
-		// retries, mas funciona em deployments sem RedisService.SetNX.
+		// retries — DOIS workers podem ver Get vazio e ambos fazer SendText.
+		//
+		// IMPORTANT: este branch é dead code em produção. `RedisService`
+		// (o único redis injetado em runtime via DI) satisfaz `SendClaimer`
+		// (implementa SetNX + Delete), então a type assertion em
+		// NewMetaDispatchHandler sempre seta `h.claimer != nil`. O branch só
+		// é exercitado por testes que passam `mockRedisGet` pelado.
+		// Mantido como rede de segurança defensiva caso alguém substitua o
+		// redis service no futuro. Se este código for invocado em
+		// produção, indica regressão arquitetural — log Warn loud.
+		h.logger.WithField("message_id", payload.MessageID).
+			Warn("meta_dispatch: SendClaimer NÃO disponível — operando em modo non-atomic (risco de duplicate send em concurrent retry)")
 		if existing, err := h.redis.Get(ctx, sentKey); err == nil && existing != "" {
 			h.logger.WithField("message_id", payload.MessageID).
 				Info("meta_dispatch: send marker exists (non-atomic); skipping duplicate")
@@ -451,6 +471,16 @@ func extractMessageText(data map[string]interface{}) string {
 					continue
 				}
 				if _, isStats := m["usage_statistics"]; isStats {
+					continue
+				}
+				// Defesa em profundidade: aceitar apenas message_type vazio
+				// (compat com shape legacy) ou explicitamente "assistant_message".
+				// tool_call_message, tool_return_message, reasoning_message
+				// carregam JSON cru no `content` — enviar isso pra Meta como
+				// texto vazaria internals ao cidadão. ExtractAgentMedia já lida
+				// com o caso assistant + envelope; este fallback só roda quando
+				// envelope.Type == "" (defensivo).
+				if mt, _ := m["message_type"].(string); mt != "" && mt != "assistant_message" {
 					continue
 				}
 				if c, ok := m["content"].(string); ok && c != "" {

--- a/internal/handlers/meta_dispatch.go
+++ b/internal/handlers/meta_dispatch.go
@@ -169,7 +169,14 @@ func (h *MetaDispatchHandler) HandleDispatch(c *gin.Context) {
 	//
 	// Sem SETNX (claimer nil), cai pra Get+Set best-effort (vulnerável a race).
 	sentKey := "meta:dispatch:sent:" + payload.MessageID
-	claimed := false
+	// success default-false: defer libera claim em qualquer return early
+	// (failure path SendText, panic, etc.). Apenas paths que PRESERVAM
+	// a claim (Set wamid bem-sucedido OU no_content — significa "vimos
+	// esse message_id e decidimos não enviar; concurrent retry deve ver
+	// inflight e ser deduped") setam success=true antes do return.
+	// Padrão é mais defensivo a edits futuros que adicionariam novas
+	// branches de retorno entre o claim e o Set final.
+	success := false
 	if h.claimer != nil {
 		ok, err := h.claimer.SetNX(ctx, sentKey, dedupValueInflight, dispatchSentMarkerTTL)
 		if err != nil {
@@ -191,16 +198,15 @@ func (h *MetaDispatchHandler) HandleDispatch(c *gin.Context) {
 			c.JSON(http.StatusOK, gin.H{"status": "already_sent", "wamid": existing})
 			return
 		}
-		claimed = true
-		// Release claim em caso de falha no SendText abaixo. Sucesso reescreve
-		// o value pro wamid (pra concurrent retries verem "done").
+		// Release claim em failure paths via defer com ctx independente
+		// (request ctx do gin pode estar cancelado quando o defer roda).
 		defer func() {
-			if !claimed {
+			if success {
 				return
 			}
-			// claimed=true significa que NÃO chegamos no Set final (SendText
-			// falhou ou algo entre claim e Set). Liberar pra Meta retentar.
-			if err := h.claimer.Delete(ctx, sentKey); err != nil {
+			releaseCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+			if err := h.claimer.Delete(releaseCtx, sentKey); err != nil {
 				h.logger.WithError(err).WithField("message_id", payload.MessageID).
 					Warn("meta_dispatch: failed to release claim on failure path")
 			}
@@ -275,6 +281,19 @@ func (h *MetaDispatchHandler) HandleDispatch(c *gin.Context) {
 		if body == "" {
 			h.logger.WithField("message_id", payload.MessageID).
 				Warn("meta_dispatch: no text content and no media envelope; nothing to send")
+			// Sobreescrever marker `inflight` → sentinela terminal ("no_content")
+			// pra dedupar concurrent retries do mesmo message_id sem deixá-los
+			// presos em 503 até o TTL de 24h (`existing == dedupValueInflight`
+			// no branch acima). Concurrent retry vê valor diferente de inflight
+			// e cai no path "already_sent" 200. Se o Set falhar (Redis blip), NÃO
+			// preservamos a claim — deixar o defer liberar pra retry refazer com
+			// estado limpo, evita ficar travado em inflight por 24h.
+			if setErr := h.redis.Set(ctx, sentKey, dedupValueNoContent, dispatchSentMarkerTTL); setErr != nil {
+				h.logger.WithError(setErr).WithField("message_id", payload.MessageID).
+					Warn("meta_dispatch: failed to write no_content marker; releasing claim via defer")
+			} else {
+				success = true
+			}
 			c.JSON(http.StatusOK, gin.H{"status": "no_content"})
 			return
 		}
@@ -301,8 +320,8 @@ func (h *MetaDispatchHandler) HandleDispatch(c *gin.Context) {
 			Warn("meta_dispatch: failed to write sent marker; duplicates possible on worker retry")
 	}
 	// Set sucesso/fail — qualquer caso, NÃO releasar a claim (queremos manter
-	// pra dedup de concurrent retries). Flag claimed=false desabilita o defer.
-	claimed = false
+	// pra dedup de concurrent retries). success=true desabilita o defer.
+	success = true
 
 	h.logger.WithFields(logrus.Fields{
 		"event":      "meta_dispatch_sent",

--- a/internal/handlers/meta_dispatch.go
+++ b/internal/handlers/meta_dispatch.go
@@ -1,0 +1,328 @@
+// Package handlers — Meta outbound dispatcher.
+//
+// `/meta/dispatch` é o callback URL interno apontado por MetaWebhookHandler
+// quando inbound chega via /meta/webhook. Quando o worker termina de processar
+// a mensagem, ele POSTa o resultado nesse endpoint, e o handler aqui chama
+// MetaGraphService.SendText (ou SendMedia) pra entregar a resposta ao cidadão
+// via Meta Graph API.
+//
+// Equivalente ao Mule `process-langgraph-callback` → `route-langgraph-response-flow`
+// → `send-via-meta-graph-flow`. Fluxo:
+//
+//	Engine → callback → /meta/dispatch
+//	  body: { message_id, status, data: {messages:[{content,...}], ...}, ... }
+//	  ↓
+//	  Gateway lookup user_number do Redis (task:metadata:{message_id})
+//	  ↓
+//	  MetaGraphService.SendText(user_number, content)
+package handlers
+
+import (
+	"context"
+	"crypto/subtle"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/sirupsen/logrus"
+
+	"github.com/prefeitura-rio/app-eai-agent-gateway/internal/models"
+	"github.com/prefeitura-rio/app-eai-agent-gateway/internal/services"
+)
+
+// dispatchSentMarkerTTL — TTL do marker "já enviado por message_id" no
+// Redis. Pra duplicates do worker callback (e.g. HTTP timeout no client
+// fazendo retry), o handler checa esse marker antes de chamar Meta de novo.
+const dispatchSentMarkerTTL = 24 * time.Hour
+
+// secureEqual compara duas strings em tempo constante (proteção contra
+// timing-attack em validação de secret).
+func secureEqual(a, b string) bool {
+	return subtle.ConstantTimeCompare([]byte(a), []byte(b)) == 1
+}
+
+// MetaSender — contrato mínimo pra dispatcher. MetaGraphService satisfaz
+// essa interface. Permite mock em testes sem subir HTTP fake completo.
+type MetaSender interface {
+	SendText(ctx context.Context, recipient, body string) (string, error)
+}
+
+// SendClaimer — interface estendida pra dedup atômico do dispatch path.
+// Implementada por RedisService (SetNX + Set + Delete).
+type SendClaimer interface {
+	RedisServiceInterface
+	SetNX(ctx context.Context, key string, value string, ttl time.Duration) (bool, error)
+	Delete(ctx context.Context, key string) error
+}
+
+// MetaDispatchHandler — recebe callbacks do worker pra outbound Meta direto.
+type MetaDispatchHandler struct {
+	sender MetaSender
+	redis  RedisServiceInterface
+	// claimer é o subset de Redis com SETNX atômico. Pode ser nil em
+	// configurações degraded (handler usa best-effort Get+Set).
+	claimer SendClaimer
+	// secret é o shared secret esperado em `X-Meta-Dispatch-Secret`. Vazio
+	// ou placeholder = fail-closed (endpoint rejeita 401).
+	secret string
+	logger *logrus.Logger
+}
+
+const dispatchSecretHeader = "X-Meta-Dispatch-Secret"
+
+// NewMetaDispatchHandler constrói handler. Se sender é nil, retorna 503
+// em runtime (Meta direct outbound desativado). Se secret vazio, endpoint
+// é fail-closed (todas chamadas viram 401). Se redis implementa SendClaimer
+// (RedisService faz), dispatch usa SETNX atômico pra dedup; senão cai pra
+// Get+Set (best-effort, vulnerável a duplicate em concurrent retries).
+func NewMetaDispatchHandler(sender MetaSender, redis RedisServiceInterface, secret string, logger *logrus.Logger) *MetaDispatchHandler {
+	h := &MetaDispatchHandler{sender: sender, redis: redis, secret: secret, logger: logger}
+	if c, ok := redis.(SendClaimer); ok {
+		h.claimer = c
+	}
+	return h
+}
+
+// MetaDispatchPayload — shape do POST que o worker envia. Match com
+// models.CallbackPayload (sent by callback_service) mas com tipagem
+// laxa nos campos data/messages porque o callback é genérico.
+type MetaDispatchPayload struct {
+	MessageID string                 `json:"message_id"`
+	Status    string                 `json:"status"`
+	Data      map[string]interface{} `json:"data"`
+	Error     *string                `json:"error,omitempty"`
+}
+
+// HandleDispatch — entrypoint do callback. Resolve user_number via Redis
+// (worker armazena em `task:metadata:{message_id}`) e chama Meta Graph.
+//
+// Auth FIRST: rejeita 401 se header `X-Meta-Dispatch-Secret` não bate com
+// o secret configurado (ou se secret está vazio/placeholder). Sem isso,
+// qualquer caller com um message_id válido (que vem da resposta do webhook
+// inbound) poderia disparar SendText arbitrário via Meta credentials.
+func (h *MetaDispatchHandler) HandleDispatch(c *gin.Context) {
+	if h.secret == "" || h.secret == "REPLACE_VIA_RUNTIME_MANAGER_PROPERTIES" {
+		h.logger.Warn("meta_dispatch: secret not configured (fail-closed)")
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "dispatch secret not configured"})
+		return
+	}
+	provided := c.GetHeader(dispatchSecretHeader)
+	if provided == "" || !secureEqual(provided, h.secret) {
+		h.logger.WithField("event", "meta_dispatch_unauthorized").Warn("Meta dispatch: invalid or missing secret header")
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+
+	if h.sender == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "meta sender not configured"})
+		return
+	}
+
+	var payload MetaDispatchPayload
+	if err := c.ShouldBindJSON(&payload); err != nil {
+		h.logger.WithError(err).Warn("meta_dispatch: invalid JSON")
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid json"})
+		return
+	}
+
+	if payload.MessageID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "message_id required"})
+		return
+	}
+
+	// Status diferente de completed: nada a enviar. Worker pode chamar com
+	// status=failed; logamos pra observabilidade mas não tentamos outbound.
+	if payload.Status != string(models.TaskStatusCompleted) {
+		h.logger.WithFields(logrus.Fields{
+			"event":      "meta_dispatch_non_completed",
+			"message_id": payload.MessageID,
+			"status":     payload.Status,
+		}).Info("Meta dispatch: non-completed status, skip outbound")
+		c.JSON(http.StatusOK, gin.H{"status": "noop"})
+		return
+	}
+
+	// Lookup user_number salvo pelo MessageHandler.EnqueueUserMessage em
+	// task:metadata:{id} (JSON: {user_number, provider}).
+	ctx := c.Request.Context()
+
+	// Dedup send-once: claim atômico no Redis evita duplicar SendText quando
+	// o worker retenta o callback (e.g. HTTP timeout no client após Meta
+	// aceitar). WhatsApp send não é idempotente.
+	//
+	// Estados:
+	//   - "inflight": SendText em progresso (set por nós antes da chamada).
+	//     Concurrent retries veem isso e retornam 503 (worker retenta após).
+	//   - "<wamid>": SendText completou. Concurrent retries retornam 200 sem
+	//     reenviar (idempotência efetiva).
+	//   - missing: ninguém tentou ainda; claim com SetNX.
+	//
+	// Sem SETNX (claimer nil), cai pra Get+Set best-effort (vulnerável a race).
+	sentKey := "meta:dispatch:sent:" + payload.MessageID
+	claimed := false
+	if h.claimer != nil {
+		ok, err := h.claimer.SetNX(ctx, sentKey, dedupValueInflight, dispatchSentMarkerTTL)
+		if err != nil {
+			h.logger.WithError(err).WithField("message_id", payload.MessageID).
+				Error("meta_dispatch: SETNX claim failed (transient)")
+			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "redis claim failed"})
+			return
+		}
+		if !ok {
+			existing, _ := h.redis.Get(ctx, sentKey)
+			if existing == dedupValueInflight {
+				h.logger.WithField("message_id", payload.MessageID).
+					Info("meta_dispatch: send in-flight; concurrent request, worker should retry")
+				c.JSON(http.StatusServiceUnavailable, gin.H{"error": "in_flight"})
+				return
+			}
+			h.logger.WithField("message_id", payload.MessageID).
+				Info("meta_dispatch: already sent; skipping duplicate")
+			c.JSON(http.StatusOK, gin.H{"status": "already_sent", "wamid": existing})
+			return
+		}
+		claimed = true
+		// Release claim em caso de falha no SendText abaixo. Sucesso reescreve
+		// o value pro wamid (pra concurrent retries verem "done").
+		defer func() {
+			if !claimed {
+				return
+			}
+			// claimed=true significa que NÃO chegamos no Set final (SendText
+			// falhou ou algo entre claim e Set). Liberar pra Meta retentar.
+			if err := h.claimer.Delete(ctx, sentKey); err != nil {
+				h.logger.WithError(err).WithField("message_id", payload.MessageID).
+					Warn("meta_dispatch: failed to release claim on failure path")
+			}
+		}()
+	} else {
+		// Fallback non-atomic: Get + Set. Vulnerável a race em concurrent
+		// retries, mas funciona em deployments sem RedisService.SetNX.
+		if existing, err := h.redis.Get(ctx, sentKey); err == nil && existing != "" {
+			h.logger.WithField("message_id", payload.MessageID).
+				Info("meta_dispatch: send marker exists (non-atomic); skipping duplicate")
+			c.JSON(http.StatusOK, gin.H{"status": "already_sent"})
+			return
+		} else if err != nil && !errors.Is(err, services.ErrKeyNotFound) {
+			h.logger.WithError(err).WithField("message_id", payload.MessageID).
+				Error("meta_dispatch: sent marker lookup failed; treat as transient")
+			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "redis lookup failed"})
+			return
+		}
+	}
+
+	metaKey := "task:metadata:" + payload.MessageID
+	metaJSON, err := h.redis.Get(ctx, metaKey)
+	if err != nil {
+		// Distingue "chave inexistente" (404 — não retentar) de "Redis down"
+		// (503 — caller deve retentar). CallbackService trata 4xx (exceto 429)
+		// como non-retriable, então classificar erro transitório como 404
+		// dropava a resposta permanentemente.
+		if errors.Is(err, services.ErrKeyNotFound) {
+			h.logger.WithField("message_id", payload.MessageID).
+				Warn("meta_dispatch: metadata key missing (likely TTL expired)")
+			c.JSON(http.StatusNotFound, gin.H{"error": "user_number not found"})
+			return
+		}
+		h.logger.WithError(err).WithField("message_id", payload.MessageID).
+			Error("meta_dispatch: redis lookup failed (transient); caller should retry")
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "redis lookup failed"})
+		return
+	}
+	if metaJSON == "" {
+		h.logger.WithField("message_id", payload.MessageID).
+			Warn("meta_dispatch: metadata empty")
+		c.JSON(http.StatusNotFound, gin.H{"error": "user_number not found"})
+		return
+	}
+	var meta map[string]interface{}
+	if err := json.Unmarshal([]byte(metaJSON), &meta); err != nil {
+		h.logger.WithError(err).Error("meta_dispatch: failed to parse stored metadata")
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "metadata parse"})
+		return
+	}
+	userNumber, _ := meta["user_number"].(string)
+	if userNumber == "" {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "user_number empty"})
+		return
+	}
+
+	// Extrai texto da resposta. Worker storage shape:
+	//   data.messages = [{ "content": "...", "role": "ai", ... }, ...]
+	// Pega o último (ou apenas o primeiro item se só tem um).
+	body := extractMessageText(payload.Data)
+	if body == "" {
+		h.logger.WithField("message_id", payload.MessageID).
+			Warn("meta_dispatch: no text content in callback data; nothing to send")
+		c.JSON(http.StatusOK, gin.H{"status": "no_content"})
+		return
+	}
+
+	wamid, err := h.sender.SendText(ctx, userNumber, body)
+	if err != nil {
+		h.logger.WithError(err).WithField("message_id", payload.MessageID).
+			Error("meta_dispatch: SendText failed")
+		c.JSON(http.StatusBadGateway, gin.H{"error": "meta send failed"})
+		return
+	}
+
+	// Marca sent ANTES de devolver 200. Sobreescreve "inflight" → wamid pra
+	// concurrent retries verem "done". Best-effort: erro no Set não bloqueia
+	// retorno (retentar 5xx faria worker retry causando o duplicate que
+	// estamos tentando evitar). Cancela o defer de release (claim agora é
+	// "done" sentinela, não in-flight).
+	if setErr := h.redis.Set(ctx, sentKey, wamid, dispatchSentMarkerTTL); setErr != nil {
+		h.logger.WithError(setErr).WithField("message_id", payload.MessageID).
+			Warn("meta_dispatch: failed to write sent marker; duplicates possible on worker retry")
+	}
+	// Set sucesso/fail — qualquer caso, NÃO releasar a claim (queremos manter
+	// pra dedup de concurrent retries). Flag claimed=false desabilita o defer.
+	claimed = false
+
+	h.logger.WithFields(logrus.Fields{
+		"event":      "meta_dispatch_sent",
+		"message_id": payload.MessageID,
+		"wamid":      wamid,
+	}).Info("Meta dispatch outbound sent")
+	c.JSON(http.StatusOK, gin.H{"status": "sent", "wamid": wamid})
+}
+
+// extractMessageText puxa a string de conteúdo do payload do worker.
+//
+// Worker `transformGoogleAgentMessages` sempre anexa um item
+// `usage_statistics` no final do array, então ler simplesmente `[last]`
+// inspeciona stats e ignora a resposta real. Scan reverso pulando entries
+// sem `content` (ou tipo telemetria) resolve.
+//
+// Fallback: data.content como string direta (shape mais simples).
+func extractMessageText(data map[string]interface{}) string {
+	if data == nil {
+		return ""
+	}
+	if rawList, ok := data["messages"]; ok {
+		if list, ok := rawList.([]interface{}); ok {
+			for i := len(list) - 1; i >= 0; i-- {
+				m, ok := list[i].(map[string]interface{})
+				if !ok {
+					continue
+				}
+				// Pular usage_statistics e variantes (não são reply real)
+				if t, _ := m["type"].(string); t == "usage_statistics" {
+					continue
+				}
+				if _, isStats := m["usage_statistics"]; isStats {
+					continue
+				}
+				if c, ok := m["content"].(string); ok && c != "" {
+					return c
+				}
+			}
+		}
+	}
+	if c, ok := data["content"].(string); ok && c != "" {
+		return c
+	}
+	return ""
+}

--- a/internal/handlers/meta_dispatch.go
+++ b/internal/handlers/meta_dispatch.go
@@ -33,10 +33,8 @@ import (
 	"github.com/prefeitura-rio/app-eai-agent-gateway/internal/services"
 )
 
-// dispatchSentMarkerTTL — TTL do marker "já enviado por message_id" no
-// Redis. Pra duplicates do worker callback (e.g. HTTP timeout no client
-// fazendo retry), o handler checa esse marker antes de chamar Meta de novo.
-const dispatchSentMarkerTTL = 24 * time.Hour
+// dispatchSentMarkerTTL + dedupValue* em meta_dedup_consts.go (compartilhado
+// com meta_webhook.go — ambos os keyspaces usam o mesmo conjunto de sentinelas).
 
 // secureEqual compara duas strings em tempo constante (proteção contra
 // timing-attack em validação de secret).
@@ -287,8 +285,13 @@ func (h *MetaDispatchHandler) HandleDispatch(c *gin.Context) {
 			// no branch acima). Concurrent retry vê valor diferente de inflight
 			// e cai no path "already_sent" 200. Se o Set falhar (Redis blip), NÃO
 			// preservamos a claim — deixar o defer liberar pra retry refazer com
-			// estado limpo, evita ficar travado em inflight por 24h.
-			if setErr := h.redis.Set(ctx, sentKey, dedupValueNoContent, dispatchSentMarkerTTL); setErr != nil {
+			// estado limpo, evita ficar travado em inflight por 24h. Ctx
+			// independente (não o request ctx do gin) pra sobreviver a cliente
+			// desconectado pós-decisão — mesma justificativa do defer release.
+			markerCtx, markerCancel := context.WithTimeout(context.Background(), 2*time.Second)
+			setErr := h.redis.Set(markerCtx, sentKey, dedupValueNoContent, dispatchSentMarkerTTL)
+			markerCancel()
+			if setErr != nil {
 				h.logger.WithError(setErr).WithField("message_id", payload.MessageID).
 					Warn("meta_dispatch: failed to write no_content marker; releasing claim via defer")
 			} else {
@@ -314,11 +317,14 @@ func (h *MetaDispatchHandler) HandleDispatch(c *gin.Context) {
 	// concurrent retries verem "done". Best-effort: erro no Set não bloqueia
 	// retorno (retentar 5xx faria worker retry causando o duplicate que
 	// estamos tentando evitar). Cancela o defer de release (claim agora é
-	// "done" sentinela, não in-flight).
-	if setErr := h.redis.Set(ctx, sentKey, wamid, dispatchSentMarkerTTL); setErr != nil {
+	// "done" sentinela, não in-flight). Ctx independente — mesmo motivo
+	// do defer release (cliente pode estar desconectado).
+	sentCtx, sentCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	if setErr := h.redis.Set(sentCtx, sentKey, wamid, dispatchSentMarkerTTL); setErr != nil {
 		h.logger.WithError(setErr).WithField("message_id", payload.MessageID).
 			Warn("meta_dispatch: failed to write sent marker; duplicates possible on worker retry")
 	}
+	sentCancel()
 	// Set sucesso/fail — qualquer caso, NÃO releasar a claim (queremos manter
 	// pra dedup de concurrent retries). success=true desabilita o defer.
 	success = true

--- a/internal/handlers/meta_dispatch.go
+++ b/internal/handlers/meta_dispatch.go
@@ -19,6 +19,7 @@ package handlers
 
 import (
 	"context"
+	"crypto/sha256"
 	"crypto/subtle"
 	"encoding/json"
 	"errors"
@@ -38,8 +39,15 @@ import (
 
 // secureEqual compara duas strings em tempo constante (proteção contra
 // timing-attack em validação de secret).
+//
+// Hash SHA256 ambos antes do compare pra eliminar leak de length:
+// `subtle.ConstantTimeCompare` retorna 0 imediatamente em length mismatch,
+// permitindo atacante deduzir comprimento do secret esperado via timing.
+// Hashing aplaina pra 32 bytes em todos os casos.
 func secureEqual(a, b string) bool {
-	return subtle.ConstantTimeCompare([]byte(a), []byte(b)) == 1
+	ah := sha256.Sum256([]byte(a))
+	bh := sha256.Sum256([]byte(b))
+	return subtle.ConstantTimeCompare(ah[:], bh[:]) == 1
 }
 
 // MetaSender — contrato pra dispatcher. MetaGraphService satisfaz nativamente.
@@ -114,8 +122,11 @@ func (h *MetaDispatchHandler) HandleDispatch(c *gin.Context) {
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "dispatch secret not configured"})
 		return
 	}
+	// Compare uniforme em TODOS os paths (incluindo header vazio) via secureEqual.
+	// SHA256 dentro de secureEqual aplaina length, e o compare é constant-time.
+	// Early-return em provided=="" introduzia timing diff distinguível.
 	provided := c.GetHeader(dispatchSecretHeader)
-	if provided == "" || !secureEqual(provided, h.secret) {
+	if !secureEqual(provided, h.secret) {
 		h.logger.WithField("event", "meta_dispatch_unauthorized").Warn("Meta dispatch: invalid or missing secret header")
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
 		return
@@ -193,7 +204,26 @@ func (h *MetaDispatchHandler) HandleDispatch(c *gin.Context) {
 			return
 		}
 		if !ok {
-			existing, _ := h.redis.Get(ctx, sentKey)
+			// SETNX false: a chave existia no momento da chamada. Inspecionar
+			// estado via Get pra discriminar in-flight / terminal / evict.
+			existing, getErr := h.redis.Get(ctx, sentKey)
+			if errors.Is(getErr, services.ErrKeyNotFound) {
+				// Race: chave evicted (Redis LRU pressure) ou TTL expirou
+				// entre SETNX false e Get. Sem claim e sem estado terminal —
+				// retornar 503 pra worker retentar; SETNX limpo no próximo
+				// round resolve. Sem isso, 200 com wamid vazio mascara o caso
+				// e o cidadão não recebe a resposta.
+				h.logger.WithField("message_id", payload.MessageID).
+					Warn("meta_dispatch: SETNX false but Get not-found (Redis LRU evict/race); will return 503 for retry")
+				c.JSON(http.StatusServiceUnavailable, gin.H{"error": "claim state lost; retry"})
+				return
+			}
+			if getErr != nil {
+				h.logger.WithError(getErr).WithField("message_id", payload.MessageID).
+					Error("meta_dispatch: SETNX false + Get failed (Redis transient); will return 503")
+				c.JSON(http.StatusServiceUnavailable, gin.H{"error": "redis lookup failed"})
+				return
+			}
 			if existing == dedupValueInflight {
 				h.logger.WithField("message_id", payload.MessageID).
 					Info("meta_dispatch: send in-flight; concurrent request, worker should retry")

--- a/internal/handlers/meta_dispatch.go
+++ b/internal/handlers/meta_dispatch.go
@@ -22,6 +22,7 @@ import (
 	"crypto/subtle"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -43,10 +44,17 @@ func secureEqual(a, b string) bool {
 	return subtle.ConstantTimeCompare([]byte(a), []byte(b)) == 1
 }
 
-// MetaSender — contrato mínimo pra dispatcher. MetaGraphService satisfaz
-// essa interface. Permite mock em testes sem subir HTTP fake completo.
+// MetaSender — contrato pra dispatcher. MetaGraphService satisfaz nativamente.
+// Inclui todos os tipos outbound que o Engine pode pedir via tool returns.
+// Mock em testes precisa cobrir só os métodos exercitados.
 type MetaSender interface {
 	SendText(ctx context.Context, recipient, body string) (string, error)
+	SendMedia(ctx context.Context, recipient, mediaType string, in services.MediaInput) (string, error)
+	SendLocation(ctx context.Context, recipient string, lat, lng float64, name, address string) (string, error)
+	SendTemplate(ctx context.Context, recipient, name, langCode string, components []map[string]interface{}) (string, error)
+	SendInteractive(ctx context.Context, recipient, subtype string, header, body, footer, action map[string]interface{}) (string, error)
+	SendReaction(ctx context.Context, recipient, wamid, emoji string) (string, error)
+	UploadMedia(ctx context.Context, mimeType string, content []byte, filename string) (string, error)
 }
 
 // SendClaimer — interface estendida pra dedup atômico do dispatch path.
@@ -249,21 +257,36 @@ func (h *MetaDispatchHandler) HandleDispatch(c *gin.Context) {
 		return
 	}
 
-	// Extrai texto da resposta. Worker storage shape:
-	//   data.messages = [{ "content": "...", "role": "ai", ... }, ...]
-	// Pega o último (ou apenas o primeiro item se só tem um).
-	body := extractMessageText(payload.Data)
-	if body == "" {
-		h.logger.WithField("message_id", payload.MessageID).
-			Warn("meta_dispatch: no text content in callback data; nothing to send")
-		c.JSON(http.StatusOK, gin.H{"status": "no_content"})
-		return
+	// Extrai envelope canônico de tool_return_message (send_whatsapp_media,
+	// generate_audio_response, send_whatsapp_flow/_buttons/_list). Quando
+	// presente, roteia por tipo. Quando ausente, cai pra texto puro do reply.
+	envelope := ExtractAgentMedia(payload.Data)
+
+	var (
+		wamid    string
+		sendKind string
+		sendErr  error
+	)
+	if envelope.Type != "" {
+		sendKind = envelope.Type
+		wamid, sendErr = h.sendByEnvelope(ctx, userNumber, envelope)
+	} else {
+		body := extractMessageText(payload.Data)
+		if body == "" {
+			h.logger.WithField("message_id", payload.MessageID).
+				Warn("meta_dispatch: no text content and no media envelope; nothing to send")
+			c.JSON(http.StatusOK, gin.H{"status": "no_content"})
+			return
+		}
+		sendKind = "text"
+		wamid, sendErr = h.sender.SendText(ctx, userNumber, body)
 	}
 
-	wamid, err := h.sender.SendText(ctx, userNumber, body)
-	if err != nil {
-		h.logger.WithError(err).WithField("message_id", payload.MessageID).
-			Error("meta_dispatch: SendText failed")
+	if sendErr != nil {
+		h.logger.WithError(sendErr).WithFields(logrus.Fields{
+			"message_id": payload.MessageID,
+			"send_kind":  sendKind,
+		}).Error("meta_dispatch: Send failed")
 		c.JSON(http.StatusBadGateway, gin.H{"error": "meta send failed"})
 		return
 	}
@@ -285,8 +308,75 @@ func (h *MetaDispatchHandler) HandleDispatch(c *gin.Context) {
 		"event":      "meta_dispatch_sent",
 		"message_id": payload.MessageID,
 		"wamid":      wamid,
+		"send_kind":  sendKind,
 	}).Info("Meta dispatch outbound sent")
-	c.JSON(http.StatusOK, gin.H{"status": "sent", "wamid": wamid})
+	c.JSON(http.StatusOK, gin.H{"status": "sent", "wamid": wamid, "kind": sendKind})
+}
+
+// sendByEnvelope roteia o envelope canônico pro método apropriado do sender.
+// Cada tipo aceita um subset distinto de campos; o helper mapeia + valida
+// mínimamente. Erros são propagados puros pra caller decidir HTTP status.
+func (h *MetaDispatchHandler) sendByEnvelope(
+	ctx context.Context, recipient string, env AgentMediaEnvelope,
+) (string, error) {
+	switch env.Type {
+	case "audio", "image", "video", "document", "sticker":
+		// Roteia por canal preferido:
+		//   1. URL direto (link público): Meta busca o conteúdo
+		//   2. Base64 inline: Gateway faz upload pra /media e usa media_id
+		// Sem nenhum dos dois, SendMedia retornaria erro genérico; tratamos
+		// explicitamente aqui.
+		input := services.MediaInput{
+			Caption:  env.Caption,
+			Filename: env.Filename,
+			Voice:    env.Voice,
+		}
+		switch {
+		case env.URL != "":
+			input.Link = env.URL
+		case env.Base64 != "":
+			content, err := services.DecodeBase64(env.Base64)
+			if err != nil {
+				return "", fmt.Errorf("decode base64 audio: %w", err)
+			}
+			mediaID, err := h.sender.UploadMedia(ctx, env.MimeType, content, env.Filename)
+			if err != nil {
+				return "", fmt.Errorf("upload media to Meta: %w", err)
+			}
+			input.ID = mediaID
+		default:
+			return "", errors.New("media envelope has neither url nor base64; nothing to send")
+		}
+		return h.sender.SendMedia(ctx, recipient, env.Type, input)
+
+	case "location":
+		if env.Latitude == nil || env.Longitude == nil {
+			return "", errors.New("location envelope missing latitude or longitude")
+		}
+		return h.sender.SendLocation(ctx, recipient, *env.Latitude, *env.Longitude, env.Name, env.Address)
+
+	case "template":
+		if env.Template == nil {
+			return "", errors.New("template envelope missing template object")
+		}
+		return h.sender.SendTemplate(ctx, recipient, env.Template.Name, env.Template.LangCode, env.Template.Components)
+
+	case "interactive":
+		if env.Interactive == nil {
+			return "", errors.New("interactive envelope missing interactive object")
+		}
+		return h.sender.SendInteractive(ctx, recipient, env.Interactive.Subtype,
+			env.Interactive.Header, env.Interactive.Body, env.Interactive.Footer, env.Interactive.Action)
+
+	case "reaction":
+		if env.ReactionToMessageID == "" {
+			return "", errors.New("reaction envelope missing reaction_to_message_id")
+		}
+		return h.sender.SendReaction(ctx, recipient, env.ReactionToMessageID, env.Emoji)
+
+	default:
+		return "", errors.New("unsupported envelope type: " + env.Type)
+	}
 }
 
 // extractMessageText puxa a string de conteúdo do payload do worker.

--- a/internal/handlers/meta_dispatch.go
+++ b/internal/handlers/meta_dispatch.go
@@ -314,20 +314,43 @@ func (h *MetaDispatchHandler) HandleDispatch(c *gin.Context) {
 	}
 
 	// Marca sent ANTES de devolver 200. Sobreescreve "inflight" → wamid pra
-	// concurrent retries verem "done". Best-effort: erro no Set não bloqueia
-	// retorno (retentar 5xx faria worker retry causando o duplicate que
-	// estamos tentando evitar). Cancela o defer de release (claim agora é
-	// "done" sentinela, não in-flight). Ctx independente — mesmo motivo
-	// do defer release (cliente pode estar desconectado).
+	// concurrent retries verem "done". Ctx independente — cliente pode estar
+	// desconectado quando o Set roda (mesmo motivo do defer release).
+	//
+	// Quando Set falha (Redis blip pós-send OK), NÃO podemos:
+	//   1. Deixar `success=true` cego — claim fica "inflight" 24h, retries do
+	//      callback_service caem em 503 indefinidamente e viram falso-positivo
+	//      DLQ.
+	//   2. Deletar a claim — concurrent retry chamaria Meta DE NOVO (mensagem
+	//      JÁ foi entregue ao cidadão); duplicate send é o cenário pior.
+	// Fallback: tentar Set com sentinel `dedupValueDone` (estado terminal sem
+	// o wamid específico). Concurrent retries veem "done" → 200 already_sent
+	// em vez de 503 ou re-send. Se AMBOS falharem (Redis fora prolongado),
+	// log Error + claim é deletada pelo defer — aceita o risco de duplicate
+	// como cenário extremo (operador atua via Redis flush manual).
 	sentCtx, sentCancel := context.WithTimeout(context.Background(), 2*time.Second)
-	if setErr := h.redis.Set(sentCtx, sentKey, wamid, dispatchSentMarkerTTL); setErr != nil {
-		h.logger.WithError(setErr).WithField("message_id", payload.MessageID).
-			Warn("meta_dispatch: failed to write sent marker; duplicates possible on worker retry")
-	}
+	markerErr := h.redis.Set(sentCtx, sentKey, wamid, dispatchSentMarkerTTL)
 	sentCancel()
-	// Set sucesso/fail — qualquer caso, NÃO releasar a claim (queremos manter
-	// pra dedup de concurrent retries). success=true desabilita o defer.
-	success = true
+	if markerErr != nil {
+		fallbackCtx, fallbackCancel := context.WithTimeout(context.Background(), 2*time.Second)
+		fallbackErr := h.redis.Set(fallbackCtx, sentKey, dedupValueDone, dispatchSentMarkerTTL)
+		fallbackCancel()
+		if fallbackErr != nil {
+			h.logger.WithFields(logrus.Fields{
+				"message_id":   payload.MessageID,
+				"wamid":        wamid,
+				"marker_err":   markerErr.Error(),
+				"fallback_err": fallbackErr.Error(),
+			}).Error("meta_dispatch: BOTH wamid Set AND fallback 'done' Set failed; claim será deletada pelo defer — RISCO de duplicate send se Meta retentar callback")
+			// success continua false → defer Delete libera a claim.
+		} else {
+			h.logger.WithError(markerErr).WithField("message_id", payload.MessageID).
+				Warn("meta_dispatch: wamid Set failed; fallback 'done' marker armazenado — concurrent retries verão already_sent")
+			success = true
+		}
+	} else {
+		success = true
+	}
 
 	h.logger.WithFields(logrus.Fields{
 		"event":      "meta_dispatch_sent",

--- a/internal/handlers/meta_dispatch_test.go
+++ b/internal/handlers/meta_dispatch_test.go
@@ -21,17 +21,30 @@ import (
 
 // ─── Mocks ───────────────────────────────────────────────────────────────
 
-type mockSender struct {
-	mu       sync.Mutex
-	calls    []struct{ recipient, body string }
-	wamid    string
-	failErr  error
+type mockSenderCall struct {
+	kind      string // "text" | "media" | "location" | "template" | "interactive" | "reaction"
+	recipient string
+	body      string
+	mediaType string
+	media     services.MediaInput
+	lat, lng  float64
+	tplName   string
+	subtype   string
+	emoji     string
+	wamidPrev string
 }
 
-func (m *mockSender) SendText(_ context.Context, recipient, body string) (string, error) {
+type mockSender struct {
+	mu      sync.Mutex
+	calls   []mockSenderCall
+	wamid   string
+	failErr error
+}
+
+func (m *mockSender) record(call mockSenderCall) (string, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.calls = append(m.calls, struct{ recipient, body string }{recipient, body})
+	m.calls = append(m.calls, call)
 	if m.failErr != nil {
 		return "", m.failErr
 	}
@@ -41,10 +54,54 @@ func (m *mockSender) SendText(_ context.Context, recipient, body string) (string
 	return m.wamid, nil
 }
 
+func (m *mockSender) SendText(_ context.Context, recipient, body string) (string, error) {
+	return m.record(mockSenderCall{kind: "text", recipient: recipient, body: body})
+}
+
+func (m *mockSender) SendMedia(_ context.Context, recipient, mediaType string, in services.MediaInput) (string, error) {
+	return m.record(mockSenderCall{kind: "media", recipient: recipient, mediaType: mediaType, media: in})
+}
+
+func (m *mockSender) SendLocation(_ context.Context, recipient string, lat, lng float64, name, address string) (string, error) {
+	return m.record(mockSenderCall{kind: "location", recipient: recipient, lat: lat, lng: lng, body: name + "|" + address})
+}
+
+func (m *mockSender) SendTemplate(_ context.Context, recipient, name, langCode string, _ []map[string]interface{}) (string, error) {
+	return m.record(mockSenderCall{kind: "template", recipient: recipient, tplName: name, body: langCode})
+}
+
+func (m *mockSender) SendInteractive(_ context.Context, recipient, subtype string, _, _, _, _ map[string]interface{}) (string, error) {
+	return m.record(mockSenderCall{kind: "interactive", recipient: recipient, subtype: subtype})
+}
+
+func (m *mockSender) SendReaction(_ context.Context, recipient, wamid, emoji string) (string, error) {
+	return m.record(mockSenderCall{kind: "reaction", recipient: recipient, wamidPrev: wamid, emoji: emoji})
+}
+
+func (m *mockSender) UploadMedia(_ context.Context, mimeType string, content []byte, _ string) (string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.calls = append(m.calls, mockSenderCall{kind: "upload", mediaType: mimeType, body: string(content)})
+	if m.failErr != nil {
+		return "", m.failErr
+	}
+	return "uploaded-media-id-1", nil
+}
+
 func (m *mockSender) callCount() int {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return len(m.calls)
+}
+
+func (m *mockSender) lastCall() *mockSenderCall {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if len(m.calls) == 0 {
+		return nil
+	}
+	c := m.calls[len(m.calls)-1]
+	return &c
 }
 
 type mockRedisGet struct {
@@ -323,6 +380,188 @@ func TestDispatch_RejectsWhenSecretUnset(t *testing.T) {
 	h.HandleDispatch(c)
 	if w.Code != http.StatusUnauthorized {
 		t.Errorf("expected 401 (fail-closed), got %d", w.Code)
+	}
+}
+
+// ─── Dispatch routing by message_type ────────────────────────────────────
+
+func dispatchPayload(messages ...interface{}) MetaDispatchPayload {
+	return MetaDispatchPayload{
+		MessageID: "msg-1",
+		Status:    "completed",
+		Data:      map[string]interface{}{"messages": messages},
+	}
+}
+
+func TestDispatch_RoutesImageEnvelope(t *testing.T) {
+	sender := &mockSender{}
+	rs := &mockRedisGet{}
+	rs.put("task:metadata:msg-1", `{"user_number":"5521"}`)
+	h := newDispatchHandler(t, sender, rs)
+	w := postJSON(t, h, dispatchPayload(
+		map[string]interface{}{
+			"message_type": "tool_return_message",
+			"name":         "send_whatsapp_media",
+			"content":      `{"status":"ok","type":"image","url":"https://example.com/img.jpg","caption":"foto"}`,
+		},
+	))
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	last := sender.lastCall()
+	if last == nil || last.kind != "media" || last.mediaType != "image" {
+		t.Errorf("expected media/image, got %+v", last)
+	}
+	if last.media.Link != "https://example.com/img.jpg" {
+		t.Errorf("expected link, got %q", last.media.Link)
+	}
+}
+
+func TestDispatch_RoutesAudioFromGenerateAudioResponse(t *testing.T) {
+	// audio_base64 → UploadMedia → SendMedia(ID=uploaded-id). Verifica que
+	// envelope base64 não falha em "media requires either id or link".
+	sender := &mockSender{}
+	rs := &mockRedisGet{}
+	rs.put("task:metadata:msg-1", `{"user_number":"5521"}`)
+	h := newDispatchHandler(t, sender, rs)
+	// "AAAA" base64-decoded = 3 bytes nulos
+	w := postJSON(t, h, dispatchPayload(
+		map[string]interface{}{
+			"message_type": "tool_return_message",
+			"name":         "generate_audio_response",
+			"content":      `{"status":"ok","audio_base64":"SGVsbG8=","mime_type":"audio/ogg"}`,
+		},
+	))
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	// Deve ter chamado UploadMedia + SendMedia (2 calls)
+	if sender.callCount() != 2 {
+		t.Fatalf("expected 2 calls (upload+send), got %d", sender.callCount())
+	}
+	if sender.calls[0].kind != "upload" {
+		t.Errorf("expected first call upload, got %+v", sender.calls[0])
+	}
+	if sender.calls[1].kind != "media" || sender.calls[1].mediaType != "audio" {
+		t.Errorf("expected second call media/audio, got %+v", sender.calls[1])
+	}
+	if sender.calls[1].media.ID != "uploaded-media-id-1" {
+		t.Errorf("expected media.ID=uploaded-media-id-1, got %q", sender.calls[1].media.ID)
+	}
+}
+
+func TestDispatch_RoutesLocationEnvelope(t *testing.T) {
+	sender := &mockSender{}
+	rs := &mockRedisGet{}
+	rs.put("task:metadata:msg-1", `{"user_number":"5521"}`)
+	h := newDispatchHandler(t, sender, rs)
+	w := postJSON(t, h, dispatchPayload(
+		map[string]interface{}{
+			"message_type": "tool_return_message",
+			"name":         "send_whatsapp_media",
+			"content":      `{"status":"ok","type":"location","latitude":-22.9,"longitude":-43.2,"name":"Praça"}`,
+		},
+	))
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	last := sender.lastCall()
+	if last == nil || last.kind != "location" {
+		t.Fatalf("expected location, got %+v", last)
+	}
+	if last.lat != -22.9 || last.lng != -43.2 {
+		t.Errorf("expected coords, got lat=%v lng=%v", last.lat, last.lng)
+	}
+}
+
+func TestDispatch_RoutesInteractiveEnvelope(t *testing.T) {
+	sender := &mockSender{}
+	rs := &mockRedisGet{}
+	rs.put("task:metadata:msg-1", `{"user_number":"5521"}`)
+	h := newDispatchHandler(t, sender, rs)
+	w := postJSON(t, h, dispatchPayload(
+		map[string]interface{}{
+			"message_type": "tool_return_message",
+			"name":         "send_whatsapp_buttons",
+			"content": map[string]interface{}{
+				"status": "ok",
+				"type":   "interactive",
+				"interactive": map[string]interface{}{
+					"subtype": "button",
+					"body":    map[string]interface{}{"text": "Confirma?"},
+					"action": map[string]interface{}{
+						"buttons": []map[string]interface{}{
+							{"type": "reply", "reply": map[string]string{"id": "yes", "title": "Sim"}},
+						},
+					},
+				},
+			},
+		},
+	))
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	last := sender.lastCall()
+	if last == nil || last.kind != "interactive" || last.subtype != "button" {
+		t.Errorf("expected interactive/button, got %+v", last)
+	}
+}
+
+func TestDispatch_RoutesReactionEnvelope(t *testing.T) {
+	sender := &mockSender{}
+	rs := &mockRedisGet{}
+	rs.put("task:metadata:msg-1", `{"user_number":"5521"}`)
+	h := newDispatchHandler(t, sender, rs)
+	w := postJSON(t, h, dispatchPayload(
+		map[string]interface{}{
+			"message_type": "tool_return_message",
+			"name":         "send_whatsapp_media",
+			"content":      `{"status":"ok","type":"reaction","reaction_to_message_id":"wamid.PREV","emoji":"❤️"}`,
+		},
+	))
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	last := sender.lastCall()
+	if last == nil || last.kind != "reaction" || last.emoji != "❤️" || last.wamidPrev != "wamid.PREV" {
+		t.Errorf("expected reaction, got %+v", last)
+	}
+}
+
+func TestDispatch_FallsBackToTextWhenNoEnvelope(t *testing.T) {
+	sender := &mockSender{}
+	rs := &mockRedisGet{}
+	rs.put("task:metadata:msg-1", `{"user_number":"5521"}`)
+	h := newDispatchHandler(t, sender, rs)
+	w := postJSON(t, h, dispatchPayload(
+		map[string]interface{}{"content": "Olá!", "role": "ai"},
+	))
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	last := sender.lastCall()
+	if last == nil || last.kind != "text" || last.body != "Olá!" {
+		t.Errorf("expected text Olá!, got %+v", last)
+	}
+}
+
+func TestDispatch_LocationEnvelopeMissingCoordsReturns502(t *testing.T) {
+	sender := &mockSender{}
+	rs := &mockRedisGet{}
+	rs.put("task:metadata:msg-1", `{"user_number":"5521"}`)
+	h := newDispatchHandler(t, sender, rs)
+	w := postJSON(t, h, dispatchPayload(
+		map[string]interface{}{
+			"message_type": "tool_return_message",
+			"name":         "send_whatsapp_media",
+			"content":      `{"status":"ok","type":"location","name":"Sem coords"}`,
+		},
+	))
+	if w.Code != http.StatusBadGateway {
+		t.Errorf("expected 502, got %d", w.Code)
+	}
+	if sender.callCount() != 0 {
+		t.Errorf("expected zero sends, got %d", sender.callCount())
 	}
 }
 

--- a/internal/handlers/meta_dispatch_test.go
+++ b/internal/handlers/meta_dispatch_test.go
@@ -889,3 +889,89 @@ func TestDispatch_AtomicDedup_WamidAndFallbackBothFailReleasesClaim(t *testing.T
 		t.Errorf("expected marker cleared after fallback fail + defer release")
 	}
 }
+
+// raceClaimer simula o caso onde SETNX retorna false (chave existe no
+// momento) mas o Get subsequente vê a chave evicted (Redis LRU pressure /
+// TTL expiry no microsegundo entre as 2 chamadas). RedisService real
+// retorna `ErrKeyNotFound` nesse caso — mockSendClaimer vanilla retornaria
+// `("", nil)` que falsamente cairia no path "already sent" com wamid vazio.
+type raceClaimer struct{ mockSendClaimer }
+
+func (r *raceClaimer) SetNX(_ context.Context, _ string, _ string, _ time.Duration) (bool, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.setNXCalls++
+	return false, nil
+}
+
+func (r *raceClaimer) Get(_ context.Context, _ string) (string, error) {
+	return "", services.ErrKeyNotFound
+}
+
+func TestDispatch_AtomicDedup_SetNXFalseGetNotFoundReturns503(t *testing.T) {
+	// Race: SETNX false (sinaliza "chave existia") + Get retorna ErrKeyNotFound
+	// (chave evicted entre as 2 chamadas). SEM o fix, handler caía no path
+	// "already_sent" com wamid vazio e 200 — mascarava o caso e o cidadão
+	// não recebia resposta. COM fix: retorna 503 pra worker retentar com
+	// SETNX limpo no próximo round.
+	sender := &mockSender{}
+	claimer := &raceClaimer{}
+	claimer.put("task:metadata:msg-RACE", `{"user_number":"5521"}`)
+	h := newDispatchHandler(t, sender, claimer)
+
+	w := postJSON(t, h, MetaDispatchPayload{
+		MessageID: "msg-RACE",
+		Status:    "completed",
+		Data: map[string]interface{}{
+			"messages": []interface{}{map[string]interface{}{"content": "olá"}},
+		},
+	})
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503 (SETNX false + Get not-found → retry), got %d body=%s", w.Code, w.Body.String())
+	}
+	if sender.callCount() != 0 {
+		t.Errorf("expected zero sends (claim state lost), got %d", sender.callCount())
+	}
+}
+
+// transientGetClaimer simula Redis blip onde SETNX false + Get retorna erro
+// não-sentinela (e.g. connection timeout). RedisService real propagaria o erro.
+// Handler deve cair em 503 (vs 200 silencioso).
+type transientGetClaimer struct{ mockSendClaimer }
+
+func (r *transientGetClaimer) SetNX(_ context.Context, _ string, _ string, _ time.Duration) (bool, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.setNXCalls++
+	return false, nil
+}
+
+func (r *transientGetClaimer) Get(_ context.Context, _ string) (string, error) {
+	return "", errors.New("redis: connection refused")
+}
+
+func TestDispatch_AtomicDedup_SetNXFalseGetErrorReturns503(t *testing.T) {
+	// SETNX false + Get com erro transient (Redis blip): handler deve
+	// retornar 503 pra worker retentar. Sem isso, erro era engolido pelo `_`
+	// e o caller tinha 200 silencioso.
+	sender := &mockSender{}
+	claimer := &transientGetClaimer{}
+	claimer.put("task:metadata:msg-TRGET", `{"user_number":"5521"}`)
+	h := newDispatchHandler(t, sender, claimer)
+
+	w := postJSON(t, h, MetaDispatchPayload{
+		MessageID: "msg-TRGET",
+		Status:    "completed",
+		Data: map[string]interface{}{
+			"messages": []interface{}{map[string]interface{}{"content": "olá"}},
+		},
+	})
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503 (Get error → retry), got %d body=%s", w.Code, w.Body.String())
+	}
+	if sender.callCount() != 0 {
+		t.Errorf("expected zero sends (lookup failed), got %d", sender.callCount())
+	}
+}

--- a/internal/handlers/meta_dispatch_test.go
+++ b/internal/handlers/meta_dispatch_test.go
@@ -172,6 +172,9 @@ type mockSendClaimer struct {
 	deleteErr   error
 	setNXCalls  int
 	deleteCalls int
+	// failKeys: lista de keys cujo Set vai falhar (uma vez por entry).
+	// Permite simular Redis blip seletivo pra testar fallback path.
+	failKeys []string
 }
 
 // SetNX só grava se a chave não existe. Retorna ok=true se gravou,
@@ -207,9 +210,18 @@ func (m *mockSendClaimer) Delete(_ context.Context, key string) error {
 // Override Set pra realmente persistir (mockRedisGet.Set é no-op stub).
 // Necessário pros testes do dedup path verem o marker `inflight` → `wamid`
 // ou `inflight` → `no_content` que o dispatcher escreve pós-claim.
+//
+// Se key estiver em failKeys, consome a primeira entry matching e retorna
+// erro (simula Redis blip transitório que se recupera no próximo Set).
 func (m *mockSendClaimer) Set(_ context.Context, key, value string, _ time.Duration) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	for i, fk := range m.failKeys {
+		if fk == key {
+			m.failKeys = append(m.failKeys[:i], m.failKeys[i+1:]...)
+			return errors.New("simulated redis blip")
+		}
+	}
 	if m.store == nil {
 		m.store = map[string]string{}
 	}
@@ -803,5 +815,77 @@ func TestDispatch_AtomicDedup_ConcurrentRetrySeesNoContentAndAcks(t *testing.T) 
 	}
 	if claimer.setNXCalls != 2 {
 		t.Errorf("expected 2 SETNX attempts, got %d", claimer.setNXCalls)
+	}
+}
+
+func TestDispatch_AtomicDedup_WamidSetFailFallbackToDone(t *testing.T) {
+	// Codex round 2 P2: quando o Set(sentKey, wamid) falha pós-send OK,
+	// tentar fallback Set(sentKey, dedupValueDone) antes de deletar a claim.
+	// Concurrent retries veem "done" → 200 already_sent (não 503 forever).
+	sender := &mockSender{wamid: "wamid.RECOVER"}
+	claimer := &mockSendClaimer{
+		// 1º Set falha (com wamid), 2º Set succeed (fallback "done").
+		failKeys: []string{"meta:dispatch:sent:msg-E"},
+	}
+	claimer.put("task:metadata:msg-E", `{"user_number":"5521"}`)
+	h := newDispatchHandler(t, sender, claimer)
+
+	w := postJSON(t, h, MetaDispatchPayload{
+		MessageID: "msg-E",
+		Status:    "completed",
+		Data: map[string]interface{}{
+			"messages": []interface{}{map[string]interface{}{"content": "olá", "role": "ai"}},
+		},
+	})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 (send OK, marker fallback OK), got %d body=%s", w.Code, w.Body.String())
+	}
+	if sender.callCount() != 1 {
+		t.Errorf("expected 1 send (mensagem foi entregue), got %d", sender.callCount())
+	}
+	if claimer.deleteCalls != 0 {
+		t.Errorf("expected zero Delete (claim preserved via fallback), got %d", claimer.deleteCalls)
+	}
+	v, ok := claimer.peek("meta:dispatch:sent:msg-E")
+	if !ok {
+		t.Fatal("expected fallback marker present, got missing")
+	}
+	if v != dedupValueDone {
+		t.Errorf("expected fallback marker=%q (sentinel terminal), got %q", dedupValueDone, v)
+	}
+}
+
+func TestDispatch_AtomicDedup_WamidAndFallbackBothFailReleasesClaim(t *testing.T) {
+	// Cenário extremo (Redis fora prolongado): BOTH wamid Set AND fallback
+	// done Set falham. Claim é deletada pelo defer — aceita risco de duplicate
+	// send em concurrent retry, mas evita inflight stuck 24h. Log Error explícito.
+	sender := &mockSender{wamid: "wamid.LOST"}
+	claimer := &mockSendClaimer{
+		// Ambos Sets do sentKey falham (1º = wamid, 2º = fallback done).
+		failKeys: []string{
+			"meta:dispatch:sent:msg-F",
+			"meta:dispatch:sent:msg-F",
+		},
+	}
+	claimer.put("task:metadata:msg-F", `{"user_number":"5521"}`)
+	h := newDispatchHandler(t, sender, claimer)
+
+	w := postJSON(t, h, MetaDispatchPayload{
+		MessageID: "msg-F",
+		Status:    "completed",
+		Data: map[string]interface{}{
+			"messages": []interface{}{map[string]interface{}{"content": "olá"}},
+		},
+	})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 (send OK), got %d body=%s", w.Code, w.Body.String())
+	}
+	if claimer.deleteCalls != 1 {
+		t.Errorf("expected 1 Delete (claim released after both Sets failed), got %d", claimer.deleteCalls)
+	}
+	if _, ok := claimer.peek("meta:dispatch:sent:msg-F"); ok {
+		t.Errorf("expected marker cleared after fallback fail + defer release")
 	}
 }

--- a/internal/handlers/meta_dispatch_test.go
+++ b/internal/handlers/meta_dispatch_test.go
@@ -1,0 +1,371 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	stdio "io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/sirupsen/logrus"
+
+	"github.com/prefeitura-rio/app-eai-agent-gateway/internal/models"
+	"github.com/prefeitura-rio/app-eai-agent-gateway/internal/services"
+)
+
+// ─── Mocks ───────────────────────────────────────────────────────────────
+
+type mockSender struct {
+	mu       sync.Mutex
+	calls    []struct{ recipient, body string }
+	wamid    string
+	failErr  error
+}
+
+func (m *mockSender) SendText(_ context.Context, recipient, body string) (string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.calls = append(m.calls, struct{ recipient, body string }{recipient, body})
+	if m.failErr != nil {
+		return "", m.failErr
+	}
+	if m.wamid == "" {
+		return "wamid.OUT", nil
+	}
+	return m.wamid, nil
+}
+
+func (m *mockSender) callCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.calls)
+}
+
+type mockRedisGet struct {
+	mu    sync.Mutex
+	store map[string]string
+	err   error
+}
+
+func (m *mockRedisGet) put(key, val string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.store == nil {
+		m.store = map[string]string{}
+	}
+	m.store[key] = val
+}
+
+func (m *mockRedisGet) Get(_ context.Context, key string) (string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.err != nil {
+		return "", m.err
+	}
+	if v, ok := m.store[key]; ok {
+		return v, nil
+	}
+	// Match real RedisService.Get semantics — missing key retorna sentinel
+	// ErrKeyNotFound (wrappado com %w), permitindo handler discriminar miss
+	// esperado (404) de Redis down (5xx).
+	return "", services.ErrKeyNotFound
+}
+
+// Stubs satisfying RedisServiceInterface — só Get matter pra dispatcher.
+func (m *mockRedisGet) SetTaskStatus(_ context.Context, _ string, _ string, _ time.Duration) error {
+	return nil
+}
+func (m *mockRedisGet) GetTaskStatus(_ context.Context, _ string) (string, error) { return "", nil }
+func (m *mockRedisGet) GetTaskResult(_ context.Context, _ string, _ interface{}) error {
+	return nil
+}
+func (m *mockRedisGet) Set(_ context.Context, _ string, _ string, _ time.Duration) error {
+	return nil
+}
+func (m *mockRedisGet) StoreCallbackURL(_ context.Context, _, _ string, _ time.Duration) error {
+	return nil
+}
+func (m *mockRedisGet) GetCallbackURL(_ context.Context, _ string) (string, error) {
+	return "", nil
+}
+func (m *mockRedisGet) SetUserLastActivity(_ context.Context, _ string, _ time.Time, _ time.Duration) error {
+	return nil
+}
+func (m *mockRedisGet) GetUserLastActivity(_ context.Context, _ string) (*time.Time, error) {
+	return nil, nil
+}
+func (m *mockRedisGet) GetUserLastActivityTTL(_ context.Context, _ string) (time.Duration, error) {
+	return 0, nil
+}
+func (m *mockRedisGet) Ping(_ context.Context) error { return nil }
+
+// ─── Helpers ─────────────────────────────────────────────────────────────
+
+const testDispatchSecret = "test-dispatch-secret"
+
+func newDispatchHandler(t *testing.T, sender MetaSender, redis RedisServiceInterface) *MetaDispatchHandler {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	logger := logrus.New()
+	logger.SetOutput(stdio.Discard)
+	return NewMetaDispatchHandler(sender, redis, testDispatchSecret, logger)
+}
+
+func postJSON(t *testing.T, h *MetaDispatchHandler, body interface{}) *httptest.ResponseRecorder {
+	t.Helper()
+	payload, _ := json.Marshal(body)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/meta/dispatch", bytes.NewReader(payload))
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Request.Header.Set("X-Meta-Dispatch-Secret", testDispatchSecret)
+	h.HandleDispatch(c)
+	return w
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────
+
+func TestDispatch_HappyPath(t *testing.T) {
+	sender := &mockSender{}
+	redis := &mockRedisGet{}
+	redis.put("task:metadata:msg-1", `{"user_number":"5521","provider":"google_agent_engine"}`)
+	h := newDispatchHandler(t, sender, redis)
+
+	w := postJSON(t, h, MetaDispatchPayload{
+		MessageID: "msg-1",
+		Status:    string(models.TaskStatusCompleted),
+		Data: map[string]interface{}{
+			"messages": []interface{}{
+				map[string]interface{}{"content": "Olá cidadão!", "role": "ai"},
+			},
+		},
+	})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	if sender.callCount() != 1 {
+		t.Fatalf("expected 1 SendText call, got %d", sender.callCount())
+	}
+	if sender.calls[0].recipient != "5521" {
+		t.Errorf("expected recipient=5521, got %q", sender.calls[0].recipient)
+	}
+	if sender.calls[0].body != "Olá cidadão!" {
+		t.Errorf("expected body=Olá cidadão!, got %q", sender.calls[0].body)
+	}
+}
+
+func TestDispatch_NoSenderConfigured(t *testing.T) {
+	h := newDispatchHandler(t, nil, &mockRedisGet{})
+	w := postJSON(t, h, MetaDispatchPayload{MessageID: "x", Status: "completed"})
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected 503 (no sender), got %d", w.Code)
+	}
+}
+
+func TestDispatch_NonCompletedStatusSkips(t *testing.T) {
+	sender := &mockSender{}
+	h := newDispatchHandler(t, sender, &mockRedisGet{})
+	w := postJSON(t, h, MetaDispatchPayload{MessageID: "x", Status: "failed"})
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 (noop), got %d", w.Code)
+	}
+	if sender.callCount() != 0 {
+		t.Errorf("expected zero sends (non-completed), got %d", sender.callCount())
+	}
+}
+
+func TestDispatch_UserNumberNotFound(t *testing.T) {
+	sender := &mockSender{}
+	rs := &mockRedisGet{} // sem put → retorna redis.Nil
+	h := newDispatchHandler(t, sender, rs)
+	w := postJSON(t, h, MetaDispatchPayload{MessageID: "missing", Status: "completed"})
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404 (key missing), got %d", w.Code)
+	}
+	if sender.callCount() != 0 {
+		t.Errorf("expected zero sends, got %d", sender.callCount())
+	}
+}
+
+func TestDispatch_AlreadySentSkipsResend(t *testing.T) {
+	// Codex P2: worker retry após Meta accept devia retornar 200 sem
+	// reenviar (WhatsApp send não é idempotente).
+	sender := &mockSender{}
+	rs := &mockRedisGet{}
+	rs.put("meta:dispatch:sent:msg-1", "wamid.PREVIOUS")
+	rs.put("task:metadata:msg-1", `{"user_number":"5521"}`)
+	h := newDispatchHandler(t, sender, rs)
+	w := postJSON(t, h, MetaDispatchPayload{
+		MessageID: "msg-1",
+		Status:    "completed",
+		Data: map[string]interface{}{
+			"messages": []interface{}{map[string]interface{}{"content": "x"}},
+		},
+	})
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 (already_sent), got %d", w.Code)
+	}
+	if sender.callCount() != 0 {
+		t.Errorf("expected zero re-sends (already_sent), got %d", sender.callCount())
+	}
+}
+
+func TestDispatch_RedisDownReturns503(t *testing.T) {
+	// Codex P2: Redis transient down não deveria virar 404 (non-retriable
+	// pelo callback_service). 5xx faz worker retentar.
+	sender := &mockSender{}
+	rs := &mockRedisGet{err: errors.New("redis: connection refused")}
+	h := newDispatchHandler(t, sender, rs)
+	w := postJSON(t, h, MetaDispatchPayload{MessageID: "msg-1", Status: "completed"})
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected 503 (redis down → retry), got %d", w.Code)
+	}
+}
+
+func TestDispatch_EmptyContentSkipsSend(t *testing.T) {
+	sender := &mockSender{}
+	redis := &mockRedisGet{}
+	redis.put("task:metadata:msg-empty", `{"user_number":"5521"}`)
+	h := newDispatchHandler(t, sender, redis)
+	w := postJSON(t, h, MetaDispatchPayload{
+		MessageID: "msg-empty",
+		Status:    "completed",
+		Data:      map[string]interface{}{"messages": []interface{}{}},
+	})
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+	if sender.callCount() != 0 {
+		t.Errorf("expected zero sends (no content), got %d", sender.callCount())
+	}
+}
+
+func TestDispatch_SendFailureReturns502(t *testing.T) {
+	sender := &mockSender{failErr: errors.New("Meta 5xx")}
+	redis := &mockRedisGet{}
+	redis.put("task:metadata:msg-fail", `{"user_number":"5521"}`)
+	h := newDispatchHandler(t, sender, redis)
+	w := postJSON(t, h, MetaDispatchPayload{
+		MessageID: "msg-fail",
+		Status:    "completed",
+		Data: map[string]interface{}{
+			"messages": []interface{}{
+				map[string]interface{}{"content": "hi"},
+			},
+		},
+	})
+	if w.Code != http.StatusBadGateway {
+		t.Errorf("expected 502, got %d", w.Code)
+	}
+}
+
+func TestDispatch_RejectsMissingSecret(t *testing.T) {
+	// Codex P1: sem auth, qualquer caller com message_id válido podia
+	// disparar SendText arbitrário. Verify 401 sem o header.
+	sender := &mockSender{}
+	redis := &mockRedisGet{}
+	redis.put("task:metadata:msg-1", `{"user_number":"5521"}`)
+	h := newDispatchHandler(t, sender, redis)
+
+	payload, _ := json.Marshal(MetaDispatchPayload{MessageID: "msg-1", Status: "completed"})
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/meta/dispatch", bytes.NewReader(payload))
+	c.Request.Header.Set("Content-Type", "application/json")
+	// SEM X-Meta-Dispatch-Secret
+	h.HandleDispatch(c)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401 (missing secret), got %d", w.Code)
+	}
+	if sender.callCount() != 0 {
+		t.Errorf("expected zero sends (rejected), got %d", sender.callCount())
+	}
+}
+
+func TestDispatch_RejectsWrongSecret(t *testing.T) {
+	sender := &mockSender{}
+	redis := &mockRedisGet{}
+	redis.put("task:metadata:msg-1", `{"user_number":"5521"}`)
+	h := newDispatchHandler(t, sender, redis)
+
+	payload, _ := json.Marshal(MetaDispatchPayload{MessageID: "msg-1", Status: "completed"})
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/meta/dispatch", bytes.NewReader(payload))
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Request.Header.Set("X-Meta-Dispatch-Secret", "wrong")
+	h.HandleDispatch(c)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401 (wrong secret), got %d", w.Code)
+	}
+}
+
+func TestDispatch_RejectsWhenSecretUnset(t *testing.T) {
+	// Fail-closed: handler com secret vazio sempre rejeita 401, mesmo se
+	// caller mandar header vazio.
+	gin.SetMode(gin.TestMode)
+	logger := logrus.New()
+	logger.SetOutput(stdio.Discard)
+	h := NewMetaDispatchHandler(&mockSender{}, &mockRedisGet{}, "", logger)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/meta/dispatch", bytes.NewReader([]byte("{}")))
+	c.Request.Header.Set("X-Meta-Dispatch-Secret", "")
+	h.HandleDispatch(c)
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401 (fail-closed), got %d", w.Code)
+	}
+}
+
+func TestExtractMessageText(t *testing.T) {
+	cases := []struct {
+		name string
+		in   map[string]interface{}
+		want string
+	}{
+		{"nil", nil, ""},
+		{"empty", map[string]interface{}{}, ""},
+		{"messages last", map[string]interface{}{
+			"messages": []interface{}{
+				map[string]interface{}{"content": "a"},
+				map[string]interface{}{"content": "b"},
+			},
+		}, "b"},
+		{"skip trailing usage_statistics by type", map[string]interface{}{
+			"messages": []interface{}{
+				map[string]interface{}{"content": "real reply", "role": "ai"},
+				map[string]interface{}{"type": "usage_statistics", "input_tokens": 10},
+			},
+		}, "real reply"},
+		{"skip trailing usage_statistics by key presence", map[string]interface{}{
+			"messages": []interface{}{
+				map[string]interface{}{"content": "another reply"},
+				map[string]interface{}{"usage_statistics": map[string]interface{}{"x": 1}},
+			},
+		}, "another reply"},
+		{"data.content fallback", map[string]interface{}{
+			"content": "direct",
+		}, "direct"},
+		{"messages with non-string", map[string]interface{}{
+			"messages": []interface{}{
+				map[string]interface{}{"content": 123},
+			},
+		}, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := extractMessageText(tc.in); got != tc.want {
+				t.Errorf("got %q want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/handlers/meta_dispatch_test.go
+++ b/internal/handlers/meta_dispatch_test.go
@@ -162,6 +162,70 @@ func (m *mockRedisGet) GetUserLastActivityTTL(_ context.Context, _ string) (time
 }
 func (m *mockRedisGet) Ping(_ context.Context) error { return nil }
 
+// mockSendClaimer estende mockRedisGet com SetNX + Delete atômicos pra
+// satisfazer SendClaimer e exercitar o atomic-dedup path do dispatcher
+// (mockRedisGet pelado faz type-assertion falhar → cai pro fallback non-
+// atomic, e os branches do success/no_content marker não rodam).
+type mockSendClaimer struct {
+	mockRedisGet
+	setNXErr    error
+	deleteErr   error
+	setNXCalls  int
+	deleteCalls int
+}
+
+// SetNX só grava se a chave não existe. Retorna ok=true se gravou,
+// false se já existia. Match RedisService.SetNX semantics.
+func (m *mockSendClaimer) SetNX(_ context.Context, key, value string, _ time.Duration) (bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.setNXCalls++
+	if m.setNXErr != nil {
+		return false, m.setNXErr
+	}
+	if m.store == nil {
+		m.store = map[string]string{}
+	}
+	if _, exists := m.store[key]; exists {
+		return false, nil
+	}
+	m.store[key] = value
+	return true, nil
+}
+
+func (m *mockSendClaimer) Delete(_ context.Context, key string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.deleteCalls++
+	if m.deleteErr != nil {
+		return m.deleteErr
+	}
+	delete(m.store, key)
+	return nil
+}
+
+// Override Set pra realmente persistir (mockRedisGet.Set é no-op stub).
+// Necessário pros testes do dedup path verem o marker `inflight` → `wamid`
+// ou `inflight` → `no_content` que o dispatcher escreve pós-claim.
+func (m *mockSendClaimer) Set(_ context.Context, key, value string, _ time.Duration) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.store == nil {
+		m.store = map[string]string{}
+	}
+	m.store[key] = value
+	return nil
+}
+
+// peek lê o valor atual do store sem passar pelo Get (que retornaria
+// ErrKeyNotFound em miss). Usado pelos testes pra inspecionar o marker.
+func (m *mockSendClaimer) peek(key string) (string, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	v, ok := m.store[key]
+	return v, ok
+}
+
 // ─── Helpers ─────────────────────────────────────────────────────────────
 
 const testDispatchSecret = "test-dispatch-secret"
@@ -606,5 +670,138 @@ func TestExtractMessageText(t *testing.T) {
 				t.Errorf("got %q want %q", got, tc.want)
 			}
 		})
+	}
+}
+
+// ─── SendClaimer path tests ─────────────────────────────────────────────
+//
+// Cobrem o atomic-dedup branch que mockRedisGet pelado nunca exercita
+// (type assertion falha → fallback non-atomic). Validam:
+//   - SETNX OK + SendText OK   → marker = wamid, claim preservada (não Delete)
+//   - SETNX OK + SendText fail → defer release Delete (sem marker)
+//   - SETNX OK + no_content    → marker = "no_content" (sentinela terminal)
+//   - SETNX false / pré-marker → 503 (inflight) | 200 already_sent (terminal)
+
+func TestDispatch_AtomicDedup_SuccessSetsMarkerToWamid(t *testing.T) {
+	sender := &mockSender{wamid: "wamid.OUT.123"}
+	claimer := &mockSendClaimer{}
+	claimer.put("task:metadata:msg-A", `{"user_number":"5521"}`)
+	h := newDispatchHandler(t, sender, claimer)
+
+	w := postJSON(t, h, MetaDispatchPayload{
+		MessageID: "msg-A",
+		Status:    "completed",
+		Data: map[string]interface{}{
+			"messages": []interface{}{map[string]interface{}{"content": "olá", "role": "ai"}},
+		},
+	})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	if sender.callCount() != 1 {
+		t.Fatalf("expected 1 send, got %d", sender.callCount())
+	}
+	if claimer.setNXCalls != 1 {
+		t.Errorf("expected 1 SETNX, got %d", claimer.setNXCalls)
+	}
+	if claimer.deleteCalls != 0 {
+		t.Errorf("expected zero Delete (claim preserved on success), got %d", claimer.deleteCalls)
+	}
+	if v, _ := claimer.peek("meta:dispatch:sent:msg-A"); v != "wamid.OUT.123" {
+		t.Errorf("expected marker=wamid.OUT.123, got %q", v)
+	}
+}
+
+func TestDispatch_AtomicDedup_SendFailureReleasesClaim(t *testing.T) {
+	sender := &mockSender{failErr: errors.New("Meta 5xx")}
+	claimer := &mockSendClaimer{}
+	claimer.put("task:metadata:msg-B", `{"user_number":"5521"}`)
+	h := newDispatchHandler(t, sender, claimer)
+
+	w := postJSON(t, h, MetaDispatchPayload{
+		MessageID: "msg-B",
+		Status:    "completed",
+		Data: map[string]interface{}{
+			"messages": []interface{}{map[string]interface{}{"content": "olá"}},
+		},
+	})
+
+	if w.Code != http.StatusBadGateway {
+		t.Fatalf("expected 502, got %d", w.Code)
+	}
+	if claimer.deleteCalls != 1 {
+		t.Errorf("expected 1 Delete (claim released for retry), got %d", claimer.deleteCalls)
+	}
+	if _, ok := claimer.peek("meta:dispatch:sent:msg-B"); ok {
+		t.Errorf("expected marker cleared after defer release, but still present")
+	}
+}
+
+func TestDispatch_AtomicDedup_NoContentSetsTerminalMarker(t *testing.T) {
+	// Payload sem text e sem media envelope → no_content path. Marker
+	// deve virar "no_content" (sentinela terminal) pra concurrent retries
+	// caírem em already_sent, não inflight=503.
+	sender := &mockSender{}
+	claimer := &mockSendClaimer{}
+	claimer.put("task:metadata:msg-C", `{"user_number":"5521"}`)
+	h := newDispatchHandler(t, sender, claimer)
+
+	w := postJSON(t, h, MetaDispatchPayload{
+		MessageID: "msg-C",
+		Status:    "completed",
+		Data:      map[string]interface{}{"messages": []interface{}{}},
+	})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 (no_content), got %d body=%s", w.Code, w.Body.String())
+	}
+	if sender.callCount() != 0 {
+		t.Errorf("expected zero sends (no content), got %d", sender.callCount())
+	}
+	if claimer.deleteCalls != 0 {
+		t.Errorf("expected zero Delete (marker preserved on no_content), got %d", claimer.deleteCalls)
+	}
+	v, ok := claimer.peek("meta:dispatch:sent:msg-C")
+	if !ok {
+		t.Fatal("expected no_content marker present, got missing")
+	}
+	if v != dedupValueNoContent {
+		t.Errorf("expected marker=%q, got %q", dedupValueNoContent, v)
+	}
+}
+
+func TestDispatch_AtomicDedup_ConcurrentRetrySeesNoContentAndAcks(t *testing.T) {
+	// 1ª chamada: no_content → marker grava "no_content".
+	// 2ª chamada (concurrent retry do mesmo message_id): SETNX false →
+	// Get vê "no_content" (≠ inflight) → cai no path already_sent 200,
+	// não 503. Sem essa garantia, retries ficariam presos em 503 por 24h.
+	sender := &mockSender{}
+	claimer := &mockSendClaimer{}
+	claimer.put("task:metadata:msg-D", `{"user_number":"5521"}`)
+	h := newDispatchHandler(t, sender, claimer)
+
+	w1 := postJSON(t, h, MetaDispatchPayload{
+		MessageID: "msg-D",
+		Status:    "completed",
+		Data:      map[string]interface{}{"messages": []interface{}{}},
+	})
+	if w1.Code != http.StatusOK {
+		t.Fatalf("first call: expected 200, got %d", w1.Code)
+	}
+
+	w2 := postJSON(t, h, MetaDispatchPayload{
+		MessageID: "msg-D",
+		Status:    "completed",
+		Data:      map[string]interface{}{"messages": []interface{}{}},
+	})
+	if w2.Code != http.StatusOK {
+		t.Fatalf("retry call: expected 200 (already_sent), got %d body=%s", w2.Code, w2.Body.String())
+	}
+	if !bytes.Contains(w2.Body.Bytes(), []byte(`"already_sent"`)) {
+		t.Errorf("retry should report already_sent, got body=%s", w2.Body.String())
+	}
+	if claimer.setNXCalls != 2 {
+		t.Errorf("expected 2 SETNX attempts, got %d", claimer.setNXCalls)
 	}
 }

--- a/internal/handlers/meta_envelope.go
+++ b/internal/handlers/meta_envelope.go
@@ -1,0 +1,308 @@
+// Package handlers — Envelope canônico Meta outbound, extraído da resposta
+// do Engine.
+//
+// Espelha o contrato Mule (`agentMedia` em `webhook-flow.xml`):
+//
+//	type      "audio"|"image"|"video"|"document"|"sticker"
+//	          |"location"|"contacts"|"interactive"|"template"|"reaction"
+//	base64    string opcional (mídia inline para upload em /media)
+//	url       string opcional (link direto, bypassa upload)
+//	mimeType  "audio/ogg", "image/jpeg", ...
+//	filename  opcional, só para document
+//	caption   opcional, image/video/document
+//	voice     bool, só para audio
+//	latitude/longitude/name/address  para location
+//	interactive  objeto, para interactive (button/list/flow)
+//	template     objeto, para template
+//	reaction_to_message_id + emoji  para reaction
+//
+// Engine emite isso via MCP tools:
+//
+//	send_whatsapp_media       → envelope canonical
+//	generate_audio_response   → audio shape compatível
+//	send_whatsapp_flow / _buttons / _list → interactive
+//
+// Tool returns aparecem em `data.messages[]` como `message_type ==
+// "tool_return_message"` com `name`/`tool_name` igualando o tool e
+// `content` JSON (string ou objeto).
+package handlers
+
+import (
+	"encoding/json"
+)
+
+// AgentMediaEnvelope é o shape canônico que o dispatcher consome para rotear
+// outbound. Vazio (`Type==""`) significa "sem media; usar SendText do reply".
+type AgentMediaEnvelope struct {
+	Type     string `json:"type"`
+	Base64   string `json:"base64,omitempty"`
+	URL      string `json:"url,omitempty"`
+	MimeType string `json:"mime_type,omitempty"`
+	Filename string `json:"filename,omitempty"`
+	Caption  string `json:"caption,omitempty"`
+	Voice    bool   `json:"voice,omitempty"`
+
+	// location
+	Latitude  *float64 `json:"latitude,omitempty"`
+	Longitude *float64 `json:"longitude,omitempty"`
+	Name      string   `json:"name,omitempty"`
+	Address   string   `json:"address,omitempty"`
+
+	// interactive (button/list/flow): action obrigatório, demais opcionais
+	Interactive *InteractiveEnvelope `json:"interactive,omitempty"`
+
+	// template (proativo fora janela 24h)
+	Template *TemplateEnvelope `json:"template,omitempty"`
+
+	// reaction
+	ReactionToMessageID string `json:"reaction_to_message_id,omitempty"`
+	Emoji               string `json:"emoji,omitempty"`
+}
+
+// InteractiveEnvelope encapsula button/list/flow payload do Engine.
+type InteractiveEnvelope struct {
+	Subtype string                 `json:"subtype"` // "button" | "list" | "flow"
+	Header  map[string]interface{} `json:"header,omitempty"`
+	Body    map[string]interface{} `json:"body,omitempty"`
+	Footer  map[string]interface{} `json:"footer,omitempty"`
+	Action  map[string]interface{} `json:"action"`
+}
+
+// TemplateEnvelope encapsula template aprovado pelo Meta.
+type TemplateEnvelope struct {
+	Name       string                   `json:"name"`
+	LangCode   string                   `json:"language_code"`
+	Components []map[string]interface{} `json:"components,omitempty"`
+}
+
+// ExtractAgentMedia procura pelo último tool_return_message no array de
+// messages cujo name/tool_name seja "send_whatsapp_media" ou
+// "generate_audio_response", e parseia o content. Retorna envelope vazio
+// (Type=="") quando não encontra ou parsing falha — caller cai pra SendText.
+//
+// Tolera content em qualquer um dos formatos:
+//   - string JSON: `"{\"type\":\"image\",\"url\":\"...\"}"`
+//   - objeto direto: `{"type":"image","url":"..."}`
+//   - objeto com text dentro: `{"text":"{\"type\":\"image\"...}"}` (legacy)
+//
+// Match no Mule `route-langgraph-response-flow:toolReturnByName`.
+func ExtractAgentMedia(data map[string]interface{}) AgentMediaEnvelope {
+	if data == nil {
+		return AgentMediaEnvelope{}
+	}
+	rawMessages, ok := data["messages"]
+	if !ok {
+		return AgentMediaEnvelope{}
+	}
+	list, ok := rawMessages.([]interface{})
+	if !ok {
+		return AgentMediaEnvelope{}
+	}
+
+	// Scan reverso pra pegar o último — Engine pode emitir múltiplos
+	// tool_return_message numa só resposta; o último é a intenção atual.
+	for i := len(list) - 1; i >= 0; i-- {
+		m, ok := list[i].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		mtype, _ := m["message_type"].(string)
+		if mtype != "tool_return_message" {
+			continue
+		}
+		name, _ := m["name"].(string)
+		if name == "" {
+			name, _ = m["tool_name"].(string)
+		}
+
+		switch name {
+		case "send_whatsapp_media", "send_whatsapp_flow", "send_whatsapp_buttons", "send_whatsapp_list":
+			if env, ok := parseCanonical(m["content"]); ok {
+				return env
+			}
+		case "generate_audio_response":
+			if env, ok := parseAudioResponse(m["content"]); ok {
+				return env
+			}
+		}
+	}
+	return AgentMediaEnvelope{}
+}
+
+// parseCanonical: envelope com `type` no top-level. Aceita string-encoded
+// JSON ou objeto direto.
+func parseCanonical(content interface{}) (AgentMediaEnvelope, bool) {
+	obj := normalizeContent(content)
+	if obj == nil {
+		return AgentMediaEnvelope{}, false
+	}
+	status, _ := obj["status"].(string)
+	if status != "" && status != "ok" {
+		return AgentMediaEnvelope{}, false
+	}
+	t, _ := obj["type"].(string)
+	if t == "" {
+		return AgentMediaEnvelope{}, false
+	}
+	env := AgentMediaEnvelope{
+		Type:                t,
+		Base64:              stringField(obj, "base64"),
+		URL:                 stringField(obj, "url"),
+		MimeType:            firstNonEmpty(stringField(obj, "mime_type"), stringField(obj, "mimeType")),
+		Filename:            stringField(obj, "filename"),
+		Caption:             stringField(obj, "caption"),
+		Voice:               boolField(obj, "voice"),
+		Name:                stringField(obj, "name"),
+		Address:             stringField(obj, "address"),
+		ReactionToMessageID: stringField(obj, "reaction_to_message_id"),
+		Emoji:               stringField(obj, "emoji"),
+	}
+	if lat, ok := floatField(obj, "latitude"); ok {
+		env.Latitude = &lat
+	}
+	if lng, ok := floatField(obj, "longitude"); ok {
+		env.Longitude = &lng
+	}
+	if interactiveRaw, ok := obj["interactive"].(map[string]interface{}); ok {
+		env.Interactive = parseInteractive(interactiveRaw)
+	}
+	if templateRaw, ok := obj["template"].(map[string]interface{}); ok {
+		env.Template = parseTemplate(templateRaw)
+	}
+	return env, true
+}
+
+// parseAudioResponse: shape específico do tool `generate_audio_response`,
+// mapeia pra envelope com Type="audio".
+func parseAudioResponse(content interface{}) (AgentMediaEnvelope, bool) {
+	obj := normalizeContent(content)
+	if obj == nil {
+		return AgentMediaEnvelope{}, false
+	}
+	if status, _ := obj["status"].(string); status != "" && status != "ok" {
+		return AgentMediaEnvelope{}, false
+	}
+	b64 := stringField(obj, "audio_base64")
+	if b64 == "" {
+		return AgentMediaEnvelope{}, false
+	}
+	mime := stringField(obj, "mime_type")
+	if mime == "" {
+		mime = "audio/ogg"
+	}
+	return AgentMediaEnvelope{
+		Type:     "audio",
+		Base64:   b64,
+		MimeType: mime,
+	}, true
+}
+
+// normalizeContent aceita string (JSON encoded) ou map. Retorna map ou nil.
+// Suporta o legacy wrapper `{"text": "<json>"}` que o Engine às vezes emite.
+func normalizeContent(content interface{}) map[string]interface{} {
+	switch v := content.(type) {
+	case nil:
+		return nil
+	case map[string]interface{}:
+		// Se tem `text` string com JSON dentro, tenta parsear (legacy).
+		if t, ok := v["text"].(string); ok && t != "" {
+			if inner := parseJSONString(t); inner != nil {
+				return inner
+			}
+		}
+		return v
+	case string:
+		return parseJSONString(v)
+	}
+	return nil
+}
+
+func parseJSONString(s string) map[string]interface{} {
+	if s == "" {
+		return nil
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal([]byte(s), &m); err != nil {
+		return nil
+	}
+	return m
+}
+
+func parseInteractive(raw map[string]interface{}) *InteractiveEnvelope {
+	subtype, _ := raw["subtype"].(string)
+	if subtype == "" {
+		// Tools antigos emitem `type` em vez de `subtype`.
+		subtype, _ = raw["type"].(string)
+	}
+	if subtype == "" {
+		return nil
+	}
+	action, _ := raw["action"].(map[string]interface{})
+	if action == nil {
+		return nil
+	}
+	env := &InteractiveEnvelope{Subtype: subtype, Action: action}
+	env.Header, _ = raw["header"].(map[string]interface{})
+	env.Body, _ = raw["body"].(map[string]interface{})
+	env.Footer, _ = raw["footer"].(map[string]interface{})
+	return env
+}
+
+func parseTemplate(raw map[string]interface{}) *TemplateEnvelope {
+	name, _ := raw["name"].(string)
+	if name == "" {
+		return nil
+	}
+	langCode, _ := raw["language_code"].(string)
+	if langCode == "" {
+		// Algumas variantes emitem {"language": {"code": "pt_BR"}} (Meta nativo).
+		if lang, ok := raw["language"].(map[string]interface{}); ok {
+			langCode, _ = lang["code"].(string)
+		}
+	}
+	if langCode == "" {
+		return nil
+	}
+	env := &TemplateEnvelope{Name: name, LangCode: langCode}
+	if compsRaw, ok := raw["components"].([]interface{}); ok {
+		for _, c := range compsRaw {
+			if m, ok := c.(map[string]interface{}); ok {
+				env.Components = append(env.Components, m)
+			}
+		}
+	}
+	return env
+}
+
+// Helpers tolerantes a tipo.
+
+func stringField(m map[string]interface{}, key string) string {
+	v, _ := m[key].(string)
+	return v
+}
+
+func boolField(m map[string]interface{}, key string) bool {
+	v, _ := m[key].(bool)
+	return v
+}
+
+func floatField(m map[string]interface{}, key string) (float64, bool) {
+	switch v := m[key].(type) {
+	case float64:
+		return v, true
+	case float32:
+		return float64(v), true
+	case int:
+		return float64(v), true
+	case int64:
+		return float64(v), true
+	}
+	return 0, false
+}
+
+func firstNonEmpty(a, b string) string {
+	if a != "" {
+		return a
+	}
+	return b
+}

--- a/internal/handlers/meta_envelope_test.go
+++ b/internal/handlers/meta_envelope_test.go
@@ -1,0 +1,208 @@
+package handlers
+
+import (
+	"testing"
+)
+
+func TestExtractAgentMedia_StringJSONContent(t *testing.T) {
+	data := map[string]interface{}{
+		"messages": []interface{}{
+			map[string]interface{}{
+				"message_type": "tool_return_message",
+				"name":         "send_whatsapp_media",
+				"content":      `{"status":"ok","type":"image","url":"https://e/x.jpg","caption":"foto"}`,
+			},
+		},
+	}
+	env := ExtractAgentMedia(data)
+	if env.Type != "image" {
+		t.Errorf("expected type=image, got %q", env.Type)
+	}
+	if env.URL != "https://e/x.jpg" {
+		t.Errorf("expected url, got %q", env.URL)
+	}
+	if env.Caption != "foto" {
+		t.Errorf("expected caption, got %q", env.Caption)
+	}
+}
+
+func TestExtractAgentMedia_ObjectContent(t *testing.T) {
+	data := map[string]interface{}{
+		"messages": []interface{}{
+			map[string]interface{}{
+				"message_type": "tool_return_message",
+				"tool_name":    "send_whatsapp_media",
+				"content": map[string]interface{}{
+					"status": "ok", "type": "audio", "url": "https://e/a.ogg",
+				},
+			},
+		},
+	}
+	env := ExtractAgentMedia(data)
+	if env.Type != "audio" || env.URL != "https://e/a.ogg" {
+		t.Errorf("got %+v", env)
+	}
+}
+
+func TestExtractAgentMedia_GenerateAudioResponse(t *testing.T) {
+	data := map[string]interface{}{
+		"messages": []interface{}{
+			map[string]interface{}{
+				"message_type": "tool_return_message",
+				"name":         "generate_audio_response",
+				"content":      `{"status":"ok","audio_base64":"AAAA","mime_type":"audio/ogg"}`,
+			},
+		},
+	}
+	env := ExtractAgentMedia(data)
+	if env.Type != "audio" || env.Base64 != "AAAA" || env.MimeType != "audio/ogg" {
+		t.Errorf("got %+v", env)
+	}
+}
+
+func TestExtractAgentMedia_LastToolReturnWins(t *testing.T) {
+	// Múltiplos tool returns — o último é a intenção corrente.
+	data := map[string]interface{}{
+		"messages": []interface{}{
+			map[string]interface{}{
+				"message_type": "tool_return_message", "name": "send_whatsapp_media",
+				"content": `{"type":"image","url":"first"}`,
+			},
+			map[string]interface{}{
+				"message_type": "tool_return_message", "name": "send_whatsapp_media",
+				"content": `{"type":"image","url":"last"}`,
+			},
+		},
+	}
+	env := ExtractAgentMedia(data)
+	if env.URL != "last" {
+		t.Errorf("expected last URL, got %q", env.URL)
+	}
+}
+
+func TestExtractAgentMedia_StatusErrorSkipped(t *testing.T) {
+	// status != ok faz envelope ficar inválido — caller cai pra texto.
+	data := map[string]interface{}{
+		"messages": []interface{}{
+			map[string]interface{}{
+				"message_type": "tool_return_message", "name": "send_whatsapp_media",
+				"content": `{"status":"error","type":"image"}`,
+			},
+		},
+	}
+	env := ExtractAgentMedia(data)
+	if env.Type != "" {
+		t.Errorf("expected empty envelope, got %+v", env)
+	}
+}
+
+func TestExtractAgentMedia_NoToolReturn(t *testing.T) {
+	data := map[string]interface{}{
+		"messages": []interface{}{
+			map[string]interface{}{"content": "Olá!", "role": "ai"},
+		},
+	}
+	env := ExtractAgentMedia(data)
+	if env.Type != "" {
+		t.Errorf("expected empty envelope, got %+v", env)
+	}
+}
+
+func TestExtractAgentMedia_NilSafe(t *testing.T) {
+	if env := ExtractAgentMedia(nil); env.Type != "" {
+		t.Errorf("expected empty on nil, got %+v", env)
+	}
+}
+
+func TestExtractAgentMedia_Location(t *testing.T) {
+	data := map[string]interface{}{
+		"messages": []interface{}{
+			map[string]interface{}{
+				"message_type": "tool_return_message", "name": "send_whatsapp_media",
+				"content": `{"status":"ok","type":"location","latitude":-22.9,"longitude":-43.2,"name":"Praça"}`,
+			},
+		},
+	}
+	env := ExtractAgentMedia(data)
+	if env.Type != "location" {
+		t.Fatalf("expected location, got %q", env.Type)
+	}
+	if env.Latitude == nil || *env.Latitude != -22.9 {
+		t.Errorf("expected lat=-22.9, got %v", env.Latitude)
+	}
+}
+
+func TestExtractAgentMedia_Interactive(t *testing.T) {
+	data := map[string]interface{}{
+		"messages": []interface{}{
+			map[string]interface{}{
+				"message_type": "tool_return_message", "name": "send_whatsapp_buttons",
+				"content": map[string]interface{}{
+					"status": "ok", "type": "interactive",
+					"interactive": map[string]interface{}{
+						"subtype": "button",
+						"action":  map[string]interface{}{"buttons": []interface{}{}},
+					},
+				},
+			},
+		},
+	}
+	env := ExtractAgentMedia(data)
+	if env.Type != "interactive" || env.Interactive == nil || env.Interactive.Subtype != "button" {
+		t.Errorf("got %+v", env)
+	}
+}
+
+// ─── FlowRegistry tests ────────────────────────────────────────────────────
+
+func TestFlowRegistry_SubstringMatch(t *testing.T) {
+	r := NewFlowRegistry("luminaria:reparo_luminaria;saude:agenda_saude", "default")
+	cases := []struct {
+		flow string
+		want string
+	}{
+		// Match é case-insensitive + substring + diacritic-insensitive.
+		{"Luminária Quebrada", "reparo_luminaria"},
+		{"LUMINARIA Quebrada", "reparo_luminaria"},
+		{"luminaria", "reparo_luminaria"},
+		{"Saúde Agendamento", "agenda_saude"},
+		{"saude agendamento", "agenda_saude"},
+		{"unknown", "default"},
+		{"", "default"},
+	}
+	for _, tc := range cases {
+		if got := r.Resolve(tc.flow); got != tc.want {
+			t.Errorf("Resolve(%q): got %q, want %q", tc.flow, got, tc.want)
+		}
+	}
+}
+
+func TestFlowRegistry_EmptyConfig(t *testing.T) {
+	r := NewFlowRegistry("", "default")
+	if got := r.Resolve("anything"); got != "default" {
+		t.Errorf("expected default, got %q", got)
+	}
+}
+
+func TestFlowRegistry_MalformedEntriesIgnored(t *testing.T) {
+	r := NewFlowRegistry("malformed;ok:service;:noflow;flow:", "")
+	if got := r.Resolve("ok"); got != "service" {
+		t.Errorf("expected service, got %q", got)
+	}
+	if got := r.Resolve("noflow"); got != "" {
+		t.Errorf("expected empty default, got %q", got)
+	}
+}
+
+func TestParseFlowResponse(t *testing.T) {
+	parsed := ParseFlowResponse(`{"endereco":"x","numero":42}`)
+	if parsed["endereco"] != "x" {
+		t.Errorf("got %v", parsed)
+	}
+	if ParseFlowResponse("") != nil {
+		t.Error("expected nil on empty")
+	}
+	if ParseFlowResponse("not json") != nil {
+		t.Error("expected nil on invalid")
+	}
+}

--- a/internal/handlers/meta_webhook.go
+++ b/internal/handlers/meta_webhook.go
@@ -1,0 +1,279 @@
+// Package handlers — Meta WhatsApp Business Cloud webhook receiver.
+//
+// Este handler é o entry point quando Gateway substitui o Mule como broker
+// entre Meta e Engine (POC `feat/meta-direct-poc`). Cobre:
+//
+//	GET  /meta/webhook  → Meta verify token handshake (challenge echo).
+//	POST /meta/webhook  → recebe Meta inbound events (HMAC validated).
+//
+// Comparação com o Mule equivalente (`meta-webhook-flow.xml`):
+//
+//   - GET: idêntico — confere hub.mode/hub.verify_token e responde o challenge.
+//   - POST: valida X-Hub-Signature-256 HMAC, parseia minimal payload (text +
+//     metadata WABA), enriquece pra UserWebhookRequest, encaminha pro
+//     MessageHandler.HandleUserWebhook existente (que cuida do RabbitMQ enqueue
+//     + Engine call). POC escopo limitado: TEXT only por enquanto — media/
+//     interactive/status callbacks seguem em fases posteriores (ver ADR draft).
+//
+// HMAC NEVER trust client-side — qualquer payload sem assinatura válida é
+// rejeitado HTTP 401 antes de qualquer parsing JSON (defesa contra crafted
+// payloads + DoS amplificação).
+package handlers
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/sirupsen/logrus"
+
+	"github.com/prefeitura-rio/app-eai-agent-gateway/internal/config"
+	"github.com/prefeitura-rio/app-eai-agent-gateway/internal/models"
+)
+
+// MetaWebhookHandler — recebe inbound webhook Meta direto (substituindo Mule).
+type MetaWebhookHandler struct {
+	cfg            *config.MetaConfig
+	messageHandler *MessageHandler
+	logger         *logrus.Logger
+}
+
+// NewMetaWebhookHandler constrói o handler injetando deps. messageHandler é
+// reutilizado do path /api/v1/message/webhook/user — Meta inbound vira chamada
+// equivalente.
+func NewMetaWebhookHandler(
+	cfg *config.MetaConfig,
+	messageHandler *MessageHandler,
+	logger *logrus.Logger,
+) *MetaWebhookHandler {
+	return &MetaWebhookHandler{
+		cfg:            cfg,
+		messageHandler: messageHandler,
+		logger:         logger,
+	}
+}
+
+// HandleVerify — Meta GET handshake.
+//
+// Documentação Meta:
+//
+//	GET https://your-callback-url?hub.mode=subscribe
+//	    &hub.verify_token=<your_verify_token>
+//	    &hub.challenge=<random_string>
+//
+// Resposta esperada: HTTP 200 com body = hub.challenge cru (texto, não JSON).
+// Mismatch de mode/token retorna 403.
+func (h *MetaWebhookHandler) HandleVerify(c *gin.Context) {
+	mode := c.Query("hub.mode")
+	token := c.Query("hub.verify_token")
+	challenge := c.Query("hub.challenge")
+
+	// Fail-closed: se VerifyToken não configurado, REJEITAR mesmo que
+	// caller envie token vazio. Caso contrário um config bug abriria
+	// verification pra qualquer request (codex P2 round 2).
+	if h.cfg.VerifyToken == "" || mode != "subscribe" || token != h.cfg.VerifyToken {
+		h.logger.WithFields(logrus.Fields{
+			"event":          "meta_verify_rejected",
+			"received_mode":  mode,
+			"token_match":    token == h.cfg.VerifyToken,
+			"verify_present": token != "",
+		}).Warn("Meta verify token mismatch")
+		c.JSON(http.StatusForbidden, gin.H{"error": "verify token mismatch"})
+		return
+	}
+
+	h.logger.WithField("event", "meta_verify_ok").Info("Meta webhook verified")
+	c.Header("Content-Type", "text/plain")
+	c.String(http.StatusOK, challenge)
+}
+
+// HandleInbound — Meta POST inbound events.
+//
+// Sequência:
+//  1. Buffer body inteiro (precisa pra HMAC + parse). MaxBodyBytes já vem do
+//     middleware RequestSizeLimit.
+//  2. Validar `X-Hub-Signature-256: sha256=<hex>` contra HMAC-SHA256(body, app_secret).
+//     Se ausente ou inválido → 401.
+//  3. Parse minimal envelope Meta (object=whatsapp_business_account, entry[].changes[]).
+//  4. Pra cada mensagem TEXT em changes[].value.messages[], delega ao
+//     MessageHandler como UserWebhookRequest.
+//  5. Status callbacks (delivered/read) por enquanto só são logados — não
+//     entram no fluxo de Engine.
+func (h *MetaWebhookHandler) HandleInbound(c *gin.Context) {
+	body, err := io.ReadAll(c.Request.Body)
+	if err != nil {
+		h.logger.WithError(err).Error("meta_inbound: failed to read body")
+		c.JSON(http.StatusBadRequest, gin.H{"error": "body read failed"})
+		return
+	}
+	// Restaura body pro caso de futuros middlewares lerem novamente.
+	c.Request.Body = io.NopCloser(bytes.NewBuffer(body))
+
+	if !h.validateSignature(c.GetHeader("X-Hub-Signature-256"), body) {
+		h.logger.WithField("event", "meta_inbound_hmac_failed").Warn("HMAC signature invalid")
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid signature"})
+		return
+	}
+
+	var envelope models.MetaWebhookEnvelope
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		h.logger.WithError(err).Error("meta_inbound: json parse failed")
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid json"})
+		return
+	}
+
+	// Meta sempre envia object="whatsapp_business_account" pra mensagens WhatsApp.
+	if envelope.Object != "whatsapp_business_account" {
+		h.logger.WithField("object", envelope.Object).Info("meta_inbound: ignoring non-whatsapp object")
+		c.JSON(http.StatusOK, gin.H{"status": "ignored", "reason": "non-whatsapp object"})
+		return
+	}
+
+	parsed, skipped := h.processEntries(&envelope)
+
+	h.logger.WithFields(logrus.Fields{
+		"event":            "meta_inbound_processed",
+		"entries":          len(envelope.Entry),
+		"messages_parsed":  parsed,
+		"messages_skipped": skipped,
+	}).Info("Meta inbound processed")
+
+	// POC fail-loud: enquanto enqueue real não estiver wired (task #106),
+	// devolver 503 quando há QUALQUER mensagem (parsed=text ou skipped=
+	// image/audio/etc). Meta vai retentar — sem isso, mensagens seriam
+	// silenciosamente descartadas após Meta receber 200. Apenas status
+	// callbacks puros (delivered/read) e envelope vazio retornam 200 normal
+	// porque não há trabalho de Engine pendente.
+	if parsed > 0 || skipped > 0 {
+		c.JSON(http.StatusServiceUnavailable, gin.H{
+			"status":  "not_ready",
+			"reason":  "POC parse-only; enqueue pending task #106",
+			"parsed":  parsed,
+			"skipped": skipped,
+		})
+		return
+	}
+
+	// Meta espera 200 OK rápido — retries agressivos se demorar.
+	c.JSON(http.StatusOK, gin.H{
+		"status":          "received",
+		"messages_parsed": parsed,
+	})
+}
+
+// validateSignature confere HMAC-SHA256 do body vs header.
+// Header shape: "sha256=<hex>".
+// Compara em constant-time pra evitar timing attacks.
+func (h *MetaWebhookHandler) validateSignature(header string, body []byte) bool {
+	const prefix = "sha256="
+	if len(header) <= len(prefix) || header[:len(prefix)] != prefix {
+		return false
+	}
+	if h.cfg.AppSecret == "" {
+		// Sem AppSecret configurado, rejeita por padrão — fail-closed.
+		h.logger.Warn("meta_inbound: AppSecret not configured; rejecting all signatures")
+		return false
+	}
+	expected := computeHMAC(body, h.cfg.AppSecret)
+	provided, err := hex.DecodeString(header[len(prefix):])
+	if err != nil {
+		return false
+	}
+	return hmac.Equal(expected, provided)
+}
+
+func computeHMAC(body []byte, secret string) []byte {
+	mac := hmac.New(sha256.New, []byte(secret))
+	_, _ = mac.Write(body)
+	return mac.Sum(nil)
+}
+
+// processEntries percorre envelope. Retorna (parsed_count, skipped_count).
+// parsed = mensagens text válidas que SERÃO enfileiradas (task #106).
+// skipped = tipos ainda não suportados (image/audio/video/etc).
+func (h *MetaWebhookHandler) processEntries(
+	envelope *models.MetaWebhookEnvelope,
+) (parsed, skipped int) {
+	for _, entry := range envelope.Entry {
+		for _, change := range entry.Changes {
+			if change.Field != "messages" {
+				continue
+			}
+			for i := range change.Value.Messages {
+				msg := &change.Value.Messages[i]
+				if _, ok := h.routeMessage(&change.Value, msg); ok {
+					parsed++
+				} else {
+					skipped++
+				}
+			}
+			// Status callbacks (delivered/read) só logados no POC.
+			for _, st := range change.Value.Statuses {
+				h.logger.WithFields(logrus.Fields{
+					"event":     "meta_status_callback",
+					"wamid":     st.ID,
+					"status":    st.Status,
+					"recipient": st.RecipientID,
+				}).Debug("Meta status callback (logged only in POC)")
+			}
+		}
+	}
+	return parsed, skipped
+}
+
+// routeMessage converte 1 mensagem Meta → UserWebhookRequest.
+//
+// POC `feat/meta-direct-poc`: o enqueue real (RabbitMQ + Engine call) NÃO
+// está implementado ainda — é fase posterior da migração. Retornar 200 OK
+// faria Meta marcar como entregue + parar retries → silent drop. Retornar
+// erro força Meta a tentar de novo, mas isso também é ruído se a feature
+// flag estiver ativada antes da hora.
+//
+// Solução pragmática neste POC: handler **NÃO É WIRED** ao MessageHandler
+// real até task #106 (full coverage). A função aqui apenas extrai o shape
+// (validando parsing) e devolve a `UserWebhookRequest` montado pro caller.
+// `HandleInbound` decide o status code: até implementação completa,
+// retorna 503 pra qualquer mensagem real (Meta tentará de novo), evitando
+// silent drop em produção. Quando o caller `HandleInbound` for atualizado
+// pra fazer enqueue real (task #106), trocar pra 200.
+func (h *MetaWebhookHandler) routeMessage(
+	value *models.MetaChangeValue, msg *models.MetaMessage,
+) (*models.UserWebhookRequest, bool) {
+	if msg.Type != "text" {
+		h.logger.WithFields(logrus.Fields{
+			"event": "meta_inbound_unsupported_type",
+			"type":  msg.Type,
+			"wamid": msg.ID,
+		}).Info("Meta inbound: non-text type not yet supported")
+		return nil, false
+	}
+	if msg.Text == nil || msg.Text.Body == "" {
+		h.logger.WithField("wamid", msg.ID).Warn("meta_inbound: empty text body")
+		return nil, false
+	}
+
+	req := &models.UserWebhookRequest{
+		UserNumber: msg.From,
+		Message:    msg.Text.Body,
+		Metadata: map[string]interface{}{
+			"source":          "meta_direct",
+			"wamid":           msg.ID,
+			"meta_timestamp":  msg.Timestamp,
+			"meta_phone_id":   value.Metadata.PhoneNumberID,
+			"meta_display_id": value.Metadata.DisplayPhoneNumber,
+		},
+	}
+
+	h.logger.WithFields(logrus.Fields{
+		"event":       "meta_inbound_text_parsed",
+		"user_number": req.UserNumber,
+		"wamid":       msg.ID,
+		"text_length": len(msg.Text.Body),
+	}).Info("Meta inbound text parsed (enqueue pending task #106)")
+	return req, true
+}

--- a/internal/handlers/meta_webhook.go
+++ b/internal/handlers/meta_webhook.go
@@ -219,15 +219,27 @@ func (h *MetaWebhookHandler) HandleInbound(c *gin.Context) {
 // pronta: callback URL setado + dispatch secret válido + Meta credentials.
 // Se incompleto, MetaWebhookHandler entra em "polling-only mode" (não wire
 // callback) em vez de devolver 200 ao Meta e silenciar a resposta depois.
+//
+// Placeholder `REPLACE_VIA_RUNTIME_MANAGER_PROPERTIES` é tratado como vazio
+// em TODOS os campos sensíveis. Sem isso, operador que esquece de hidratar
+// uma das variáveis no Infisical/SecretManager teria a chain "passando" no
+// gate mas falhando no runtime quando Meta Graph rejeita Bearer token literal
+// "REPLACE_...".
 func (h *MetaWebhookHandler) dispatchReady() bool {
-	if h.cfg.SelfCallbackURL == "" {
+	if h.cfg.SelfCallbackURL == "" ||
+		h.cfg.SelfCallbackURL == "REPLACE_VIA_RUNTIME_MANAGER_PROPERTIES" {
 		return false
 	}
 	if h.cfg.DispatchSecret == "" ||
 		h.cfg.DispatchSecret == "REPLACE_VIA_RUNTIME_MANAGER_PROPERTIES" {
 		return false
 	}
-	if h.cfg.SystemUserToken == "" || h.cfg.PhoneNumberID == "" {
+	if h.cfg.SystemUserToken == "" ||
+		h.cfg.SystemUserToken == "REPLACE_VIA_RUNTIME_MANAGER_PROPERTIES" {
+		return false
+	}
+	if h.cfg.PhoneNumberID == "" ||
+		h.cfg.PhoneNumberID == "REPLACE_VIA_RUNTIME_MANAGER_PROPERTIES" {
 		return false
 	}
 	return true
@@ -309,10 +321,17 @@ func (h *MetaWebhookHandler) processEntries(
 
 				// Persistir delivery status no Redis pra Engine/operadores
 				// poderem consultar quando handoff humano precisa saber se
-				// notice chegou. Best-effort; falha não bloqueia 200 ao Meta.
+				// notice chegou. Best-effort; falha não bloqueia 200 ao Meta —
+				// log Warn pra rastreabilidade caso Redis blip degrade o trail.
 				if h.dedup != nil && st.ID != "" {
 					key := "meta:status:" + st.ID
-					_ = h.dedup.Set(ctx, key, st.Status, dedupTTL)
+					if err := h.dedup.Set(ctx, key, st.Status, dedupTTL); err != nil {
+						h.logger.WithError(err).WithFields(logrus.Fields{
+							"event":  "meta_status_persist_failed",
+							"wamid":  st.ID,
+							"status": st.Status,
+						}).Warn("meta_inbound: failed to persist status callback (best-effort)")
+					}
 				}
 			}
 		}

--- a/internal/handlers/meta_webhook.go
+++ b/internal/handlers/meta_webhook.go
@@ -69,6 +69,11 @@ type MetaDedupChecker interface {
 const (
 	dedupValueInflight = "inflight"
 	dedupValueDone     = "done"
+	// dedupValueNoContent — sentinela terminal no `meta:dispatch:sent:<id>`
+	// quando o dispatch decide não enviar (callback sem texto nem media
+	// envelope). Diferente de `dedupValueInflight`: concurrent retries veem
+	// "already_sent" em vez de 503, evitando ficar presos até o TTL de 24h.
+	dedupValueNoContent = "no_content"
 )
 
 // MessageEnqueuer — contrato mínimo que MetaWebhookHandler precisa pra

--- a/internal/handlers/meta_webhook.go
+++ b/internal/handlers/meta_webhook.go
@@ -39,11 +39,6 @@ import (
 	"github.com/prefeitura-rio/app-eai-agent-gateway/internal/models"
 )
 
-// dedupTTL define quanto tempo um wamid fica marcado como "já processado"
-// no Redis. Meta retenta agressivamente nos primeiros minutos; 24h é o
-// máximo nominal de uma session window do WhatsApp Business.
-const dedupTTL = 24 * time.Hour
-
 // MetaDedupChecker — interface mínima que o handler precisa pra idempotência.
 //   - `SetNX` faz claim atômico (SET key value NX EX ttl) — retorna true se
 //     claim foi adquirida (chave não existia), false se já estava ocupada.
@@ -61,20 +56,7 @@ type MetaDedupChecker interface {
 	Delete(ctx context.Context, key string) error
 }
 
-// Sentinelas pra value da claim no Redis. "inflight" significa que o
-// request original ainda está processando (não devolveu 200 ao Meta ainda),
-// então duplicatas devem retornar 503 pra Meta continuar retentando. "done"
-// significa que primeiro request já confirmou — duplicatas viram 200 sem
-// reprocessar.
-const (
-	dedupValueInflight = "inflight"
-	dedupValueDone     = "done"
-	// dedupValueNoContent — sentinela terminal no `meta:dispatch:sent:<id>`
-	// quando o dispatch decide não enviar (callback sem texto nem media
-	// envelope). Diferente de `dedupValueInflight`: concurrent retries veem
-	// "already_sent" em vez de 503, evitando ficar presos até o TTL de 24h.
-	dedupValueNoContent = "no_content"
-)
+// Constantes de dedup (TTL + sentinelas) em meta_dedup_consts.go.
 
 // MessageEnqueuer — contrato mínimo que MetaWebhookHandler precisa pra
 // publicar mensagens no MessageHandler. Existe pra permitir mock em testes.
@@ -467,19 +449,28 @@ func (h *MetaWebhookHandler) handleMessage(
 	// Sentinela: na saída, claim recebe:
 	//   - routeFailed/routeSkipped → Delete (libera, Meta retry consegue replay)
 	//   - routeOK → Set("done") com mesmo TTL (upgrade in-flight → done)
+	//
+	// Nota: NÃO usamos o pattern `success := false; defer if !success {...}` do
+	// meta_dispatch.go porque aqui temos 3 ações terminais (don't-touch /
+	// Delete / Set-done), não 2 (release / keep). `outcome routeOutcome` carrega
+	// essa cardinalidade direta; reduzir a binário perderia clareza. Ctx
+	// independente no defer pelo mesmo motivo do dispatch — cliente pode estar
+	// desconectado quando o release roda.
 	outcome := routeFailed
 	defer func() {
 		if !claimed {
 			return
 		}
+		releaseCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
 		switch outcome {
 		case routeFailed, routeSkipped:
-			if err := h.dedup.Delete(ctx, dedupKey); err != nil {
+			if err := h.dedup.Delete(releaseCtx, dedupKey); err != nil {
 				h.logger.WithError(err).WithField("wamid", msg.ID).
 					Warn("meta_inbound: dedup release failed; retries blocked até TTL")
 			}
 		case routeOK:
-			if err := h.dedup.Set(ctx, dedupKey, dedupValueDone, dedupTTL); err != nil {
+			if err := h.dedup.Set(releaseCtx, dedupKey, dedupValueDone, dedupTTL); err != nil {
 				h.logger.WithError(err).WithField("wamid", msg.ID).
 					Warn("meta_inbound: dedup upgrade to done failed; duplicates can still be in-flight")
 			}

--- a/internal/handlers/meta_webhook.go
+++ b/internal/handlers/meta_webhook.go
@@ -89,6 +89,7 @@ type MetaWebhookHandler struct {
 	cfg            *config.MetaConfig
 	messageHandler MessageEnqueuer
 	dedup          MetaDedupChecker
+	flowRegistry   *FlowRegistry
 	logger         *logrus.Logger
 }
 
@@ -107,6 +108,7 @@ func NewMetaWebhookHandler(
 		cfg:            cfg,
 		messageHandler: messageHandler,
 		dedup:          dedup,
+		flowRegistry:   NewFlowRegistry(cfg.FlowRegistry, cfg.FlowDefaultService),
 		logger:         logger,
 	}
 }
@@ -301,15 +303,29 @@ func (h *MetaWebhookHandler) processEntries(
 					failed++
 				}
 			}
-			// Status callbacks (delivered/read/failed) logados como telemetria.
-			// Não disparam Engine — apenas observabilidade.
+			// Status callbacks (delivered/read/failed): emitir como evento
+			// estruturado pra observabilidade + persistir failure status no
+			// Redis pra worker/Engine consultarem se quiser. Não dispara
+			// Engine outbound — apenas signal.
 			for _, st := range change.Value.Statuses {
+				lvl := logrus.InfoLevel
+				if st.Status == "failed" {
+					lvl = logrus.WarnLevel
+				}
 				h.logger.WithFields(logrus.Fields{
-					"event":     "meta_status_callback",
-					"wamid":     st.ID,
-					"status":    st.Status,
-					"recipient": st.RecipientID,
-				}).Debug("Meta status callback")
+					"event":            "meta_status_callback",
+					"wamid":            st.ID,
+					"status":           st.Status,
+					"recipient_prefix": maskPhone(st.RecipientID),
+				}).Log(lvl, "Meta status callback")
+
+				// Persistir delivery status no Redis pra Engine/operadores
+				// poderem consultar quando handoff humano precisa saber se
+				// notice chegou. Best-effort; falha não bloqueia 200 ao Meta.
+				if h.dedup != nil && st.ID != "" {
+					key := "meta:status:" + st.ID
+					_ = h.dedup.Set(ctx, key, st.Status, dedupTTL)
+				}
 			}
 		}
 	}
@@ -325,6 +341,50 @@ const (
 	routeSkipped
 	routeFailed
 )
+
+// isFromBotItself — anti-loop guard: detecta inbound originário do próprio
+// número WABA do bot. Ocorre quando outbound wamid retorna como webhook
+// (raro em produção mas observado em sandboxes); processar como mensagem
+// cidadã faria o bot se responder em loop. Match comparing msg.From com
+// metadata.PhoneNumberID OU metadata.DisplayPhoneNumber.
+func isFromBotItself(value *models.MetaChangeValue, msg *models.MetaMessage) bool {
+	if msg == nil || msg.From == "" {
+		return false
+	}
+	// PhoneNumberID é o id interno da WABA (não bate com From, que é o
+	// número E.164 sem '+'). DisplayPhoneNumber é o número formatado pra
+	// display ("5521989091014" ou "55 21 9 8909-1014"). Normalize ambos pra
+	// dígitos antes de comparar.
+	from := normalizeDigits(msg.From)
+	if from == "" {
+		return false
+	}
+	if normalizeDigits(value.Metadata.DisplayPhoneNumber) == from {
+		return true
+	}
+	return false
+}
+
+// normalizeDigits remove tudo exceto dígitos. "55 21 9 8909-1014" → "5521989091014".
+func normalizeDigits(s string) string {
+	out := make([]byte, 0, len(s))
+	for i := 0; i < len(s); i++ {
+		if s[i] >= '0' && s[i] <= '9' {
+			out = append(out, s[i])
+		}
+	}
+	return string(out)
+}
+
+// maskPhone mascara LGPD: "5521989091014" → "55219890…". Para status
+// callbacks logging onde recipient não-PII é suficiente.
+func maskPhone(phone string) string {
+	digits := normalizeDigits(phone)
+	if len(digits) <= 8 {
+		return digits
+	}
+	return digits[:8] + "…"
+}
 
 // handleMessage: claim atômico (SETNX) → parse → enqueue → release on failure.
 //
@@ -346,6 +406,18 @@ func (h *MetaWebhookHandler) handleMessage(
 	value *models.MetaChangeValue,
 	msg *models.MetaMessage,
 ) routeOutcome {
+	// Anti-loop guard: dropar mensagens originadas do próprio bot. Evita
+	// cascade bot→bot caso outbound vire inbound por erro de config Meta.
+	if isFromBotItself(value, msg) {
+		h.logger.WithFields(logrus.Fields{
+			"event":     "meta_inbound_self_loop_drop",
+			"wamid":     msg.ID,
+			"from":      msg.From,
+			"waba_display": value.Metadata.DisplayPhoneNumber,
+		}).Warn("Meta inbound: message from own WABA number; drop to break loop")
+		return routeDup // 200 OK semantics — não retentar essa
+	}
+
 	var (
 		claimed     bool
 		dedupKey    string
@@ -555,7 +627,7 @@ func (h *MetaWebhookHandler) parseMessage(
 		// button_reply / list_reply / nfm_reply (WhatsApp Flow) — downcast pra
 		// text preservando id em extra_metadata pra Engine roteiar pelo
 		// Flow registry ou pelo botão clicado.
-		body, extra := flattenInteractive(msg.Interactive)
+		body, extra := h.flattenInteractive(msg.Interactive)
 		if body == "" {
 			return nil, routeSkipped
 		}
@@ -617,8 +689,9 @@ func mediaFromMeta(msg *models.MetaMessage) map[string]interface{} {
 
 // flattenInteractive converte interactive payload (button_reply / list_reply
 // / nfm_reply) numa string + metadata extra. Retorna ("", nil) se shape
-// desconhecido.
-func flattenInteractive(intr *models.MetaInteractive) (string, map[string]interface{}) {
+// desconhecido. Pra nfm_reply, usa flowRegistry pra resolver service_name
+// e parsear response_json em metadata.form_submission estruturado (ADR-024).
+func (h *MetaWebhookHandler) flattenInteractive(intr *models.MetaInteractive) (string, map[string]interface{}) {
 	if intr == nil {
 		return "", nil
 	}
@@ -636,13 +709,14 @@ func flattenInteractive(intr *models.MetaInteractive) (string, map[string]interf
 			return "", nil
 		}
 		return intr.ListReply.Title, map[string]interface{}{
-			"interactive_kind":          "list_reply",
-			"interactive_id":            intr.ListReply.ID,
-			"interactive_description":   intr.ListReply.Description,
+			"interactive_kind":        "list_reply",
+			"interactive_id":          intr.ListReply.ID,
+			"interactive_description": intr.ListReply.Description,
 		}
 	case "nfm_reply":
-		// WhatsApp Flow submission. response_json carrega o form completo;
-		// downcast pra text preservando o JSON cru em metadata.
+		// WhatsApp Flow submission. Resolve service_name via registry e
+		// inclui form_submission estruturado (parse response_json). Engine
+		// dispatch pra MCP correto sem precisar inspecionar raw JSON.
 		if intr.NFMReply == nil {
 			return "", nil
 		}
@@ -650,11 +724,21 @@ func flattenInteractive(intr *models.MetaInteractive) (string, map[string]interf
 		if intr.NFMReply.Body != "" {
 			body = intr.NFMReply.Body
 		}
-		return body, map[string]interface{}{
+		extra := map[string]interface{}{
 			"interactive_kind":  "nfm_reply",
 			"flow_name":         intr.NFMReply.Name,
 			"flow_response_raw": intr.NFMReply.ResponseJSON,
 		}
+		if intr.NFMReply.FlowToken != "" {
+			extra["flow_token"] = intr.NFMReply.FlowToken
+		}
+		if service := h.flowRegistry.Resolve(intr.NFMReply.Name); service != "" {
+			extra["service_name"] = service
+		}
+		if parsed := ParseFlowResponse(intr.NFMReply.ResponseJSON); parsed != nil {
+			extra["form_submission"] = parsed
+		}
+		return body, extra
 	}
 	return "", nil
 }

--- a/internal/handlers/meta_webhook.go
+++ b/internal/handlers/meta_webhook.go
@@ -494,25 +494,23 @@ func (h *MetaWebhookHandler) handleMessage(
 	}
 
 	// Wire callback apenas quando TODA a chain dispatch está pronta: URL +
-	// secret + Meta credentials. Wire parcial (URL setado mas dispatch falha
-	// auth ou Meta credentials ausentes) faz Meta receber 200 do webhook
-	// inbound e a resposta jamais chega ao cidadão.
-	if h.dispatchReady() {
-		url := h.cfg.SelfCallbackURL
-		req.CallbackURL = &url
-	} else if h.cfg.SelfCallbackURL != "" {
-		// Operator configurou intenção de Meta-direct (SelfCallbackURL setado)
-		// mas chain incompleta (secret ou Meta credentials). Refusar a enqueue
-		// pra forçar Meta retry — sem isso a mensagem fica órfã no Redis.
+	// secret + Meta credentials. Sem isso a mensagem entra na fila sem callback,
+	// worker armazena resposta em Redis, e nunca volta pro cidadão (órfã).
+	// O webhook só é registrado quando META_DIRECT_ENABLED=true → qualquer
+	// chain incompleta aqui é misconfiguration; rejeita pra forçar Meta retry.
+	if !h.dispatchReady() {
 		h.logger.WithFields(logrus.Fields{
-			"event":              "meta_inbound_dispatch_not_ready",
-			"wamid":              msg.ID,
-			"has_dispatch_secret": h.cfg.DispatchSecret != "",
-			"has_meta_creds":     h.cfg.SystemUserToken != "" && h.cfg.PhoneNumberID != "",
+			"event":                 "meta_inbound_dispatch_not_ready",
+			"wamid":                 msg.ID,
+			"self_callback_url_set": h.cfg.SelfCallbackURL != "",
+			"has_dispatch_secret":   h.cfg.DispatchSecret != "",
+			"has_meta_creds":        h.cfg.SystemUserToken != "" && h.cfg.PhoneNumberID != "",
 		}).Error("Meta inbound: dispatch chain incomplete; rejecting to force Meta retry")
 		outcome = routeFailed
 		return outcome
 	}
+	url := h.cfg.SelfCallbackURL
+	req.CallbackURL = &url
 
 	// Enqueue real via MessageHandler (mesmo path do /api/v1/message/webhook/user).
 	if h.messageHandler == nil {

--- a/internal/handlers/meta_webhook.go
+++ b/internal/handlers/meta_webhook.go
@@ -22,12 +22,15 @@ package handlers
 
 import (
 	"bytes"
+	"context"
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
@@ -36,24 +39,74 @@ import (
 	"github.com/prefeitura-rio/app-eai-agent-gateway/internal/models"
 )
 
+// dedupTTL define quanto tempo um wamid fica marcado como "já processado"
+// no Redis. Meta retenta agressivamente nos primeiros minutos; 24h é o
+// máximo nominal de uma session window do WhatsApp Business.
+const dedupTTL = 24 * time.Hour
+
+// MetaDedupChecker — interface mínima que o handler precisa pra idempotência.
+//   - `SetNX` faz claim atômico (SET key value NX EX ttl) — retorna true se
+//     claim foi adquirida (chave não existia), false se já estava ocupada.
+//   - `Get` lê o valor atual da claim. Usado pra discriminar claim in-flight
+//     ("inflight") de claim completada ("done").
+//   - `Set` upgrade da claim com value novo (de "inflight" pra "done") quando
+//     enqueue completa com sucesso. Mesmo TTL que SetNX original.
+//   - `Delete` libera a claim quando enqueue falha, pra Meta retry conseguir
+//     reprocessar até dedupTTL expirar.
+// Implementada pelo RedisService.
+type MetaDedupChecker interface {
+	SetNX(ctx context.Context, key string, value string, ttl time.Duration) (bool, error)
+	Get(ctx context.Context, key string) (string, error)
+	Set(ctx context.Context, key string, value string, ttl time.Duration) error
+	Delete(ctx context.Context, key string) error
+}
+
+// Sentinelas pra value da claim no Redis. "inflight" significa que o
+// request original ainda está processando (não devolveu 200 ao Meta ainda),
+// então duplicatas devem retornar 503 pra Meta continuar retentando. "done"
+// significa que primeiro request já confirmou — duplicatas viram 200 sem
+// reprocessar.
+const (
+	dedupValueInflight = "inflight"
+	dedupValueDone     = "done"
+)
+
+// MessageEnqueuer — contrato mínimo que MetaWebhookHandler precisa pra
+// publicar mensagens no MessageHandler. Existe pra permitir mock em testes.
+// MessageHandler (concrete) satisfaz essa interface naturalmente.
+type MessageEnqueuer interface {
+	EnqueueUserMessage(
+		ctx context.Context,
+		req *models.UserWebhookRequest,
+		requestID string,
+		traceHeaders map[string]interface{},
+		opts EnqueueOptions,
+	) (*EnqueueResult, error)
+}
+
 // MetaWebhookHandler — recebe inbound webhook Meta direto (substituindo Mule).
 type MetaWebhookHandler struct {
 	cfg            *config.MetaConfig
-	messageHandler *MessageHandler
+	messageHandler MessageEnqueuer
+	dedup          MetaDedupChecker
 	logger         *logrus.Logger
 }
 
 // NewMetaWebhookHandler constrói o handler injetando deps. messageHandler é
 // reutilizado do path /api/v1/message/webhook/user — Meta inbound vira chamada
-// equivalente.
+// equivalente. dedup pode ser nil (modo POC sem Redis); idempotência fica
+// desativada nesse caso e Meta retries podem duplicar. messageHandler também
+// pode ser nil em testes — handler retorna failed (503) pra qualquer mensagem.
 func NewMetaWebhookHandler(
 	cfg *config.MetaConfig,
-	messageHandler *MessageHandler,
+	messageHandler MessageEnqueuer,
+	dedup MetaDedupChecker,
 	logger *logrus.Logger,
 ) *MetaWebhookHandler {
 	return &MetaWebhookHandler{
 		cfg:            cfg,
 		messageHandler: messageHandler,
+		dedup:          dedup,
 		logger:         logger,
 	}
 }
@@ -134,36 +187,60 @@ func (h *MetaWebhookHandler) HandleInbound(c *gin.Context) {
 		return
 	}
 
-	parsed, skipped := h.processEntries(&envelope)
+	enqueued, dup, skipped, failed := h.processEntries(c.Request.Context(), &envelope)
 
 	h.logger.WithFields(logrus.Fields{
-		"event":            "meta_inbound_processed",
-		"entries":          len(envelope.Entry),
-		"messages_parsed":  parsed,
-		"messages_skipped": skipped,
+		"event":             "meta_inbound_processed",
+		"entries":           len(envelope.Entry),
+		"messages_enqueued": enqueued,
+		"messages_dup":      dup,
+		"messages_skipped":  skipped,
+		"messages_failed":   failed,
 	}).Info("Meta inbound processed")
 
-	// POC fail-loud: enquanto enqueue real não estiver wired (task #106),
-	// devolver 503 quando há QUALQUER mensagem (parsed=text ou skipped=
-	// image/audio/etc). Meta vai retentar — sem isso, mensagens seriam
-	// silenciosamente descartadas após Meta receber 200. Apenas status
-	// callbacks puros (delivered/read) e envelope vazio retornam 200 normal
-	// porque não há trabalho de Engine pendente.
-	if parsed > 0 || skipped > 0 {
+	// Se TODAS as mensagens foram enqueued ou dup-skipped: 200. Meta para de
+	// retentar. Status callbacks puros (delivered/read) também caem aqui.
+	//
+	// Se houve `failed > 0` (enqueue Redis/RabbitMQ down) ou `skipped > 0`
+	// (tipo ainda não suportado): 503 pra Meta retentar. Isso garante:
+	//   - Redis/RabbitMQ flapping → retry recupera sem perda
+	//   - tipos novos (sticker, document) ficam in-flight até a gente
+	//     implementar suporte; só fica realmente perdido se Meta esgotar
+	//     retry window (~24h), e nesse caso o log "_skipped" sinaliza.
+	if failed > 0 || skipped > 0 {
 		c.JSON(http.StatusServiceUnavailable, gin.H{
-			"status":  "not_ready",
-			"reason":  "POC parse-only; enqueue pending task #106",
-			"parsed":  parsed,
-			"skipped": skipped,
+			"status":   "not_ready",
+			"enqueued": enqueued,
+			"dup":      dup,
+			"skipped":  skipped,
+			"failed":   failed,
 		})
 		return
 	}
 
-	// Meta espera 200 OK rápido — retries agressivos se demorar.
 	c.JSON(http.StatusOK, gin.H{
-		"status":          "received",
-		"messages_parsed": parsed,
+		"status":   "received",
+		"enqueued": enqueued,
+		"dup":      dup,
 	})
+}
+
+// dispatchReady — true se toda a chain pra outbound via /meta/dispatch está
+// pronta: callback URL setado + dispatch secret válido + Meta credentials.
+// Se incompleto, MetaWebhookHandler entra em "polling-only mode" (não wire
+// callback) em vez de devolver 200 ao Meta e silenciar a resposta depois.
+func (h *MetaWebhookHandler) dispatchReady() bool {
+	if h.cfg.SelfCallbackURL == "" {
+		return false
+	}
+	if h.cfg.DispatchSecret == "" ||
+		h.cfg.DispatchSecret == "REPLACE_VIA_RUNTIME_MANAGER_PROPERTIES" {
+		return false
+	}
+	if h.cfg.SystemUserToken == "" || h.cfg.PhoneNumberID == "" {
+		return false
+	}
+	return true
 }
 
 // validateSignature confere HMAC-SHA256 do body vs header.
@@ -193,12 +270,19 @@ func computeHMAC(body []byte, secret string) []byte {
 	return mac.Sum(nil)
 }
 
-// processEntries percorre envelope. Retorna (parsed_count, skipped_count).
-// parsed = mensagens text válidas que SERÃO enfileiradas (task #106).
-// skipped = tipos ainda não suportados (image/audio/video/etc).
+// processEntries percorre envelope, dedup por wamid via Redis, parse + enqueue
+// no MessageHandler.
+//
+// Retorna contadores discriminados pra resposta + telemetria:
+//
+//	enqueued — mensagem nova publicada no RabbitMQ com sucesso
+//	dup      — wamid já visto em <dedupTTL; skip silencioso (Meta retry esperado)
+//	skipped  — tipo ainda não suportado (sticker, document, contacts, etc.)
+//	failed   — Redis/RabbitMQ down ou Engine call falhou no enqueue path
 func (h *MetaWebhookHandler) processEntries(
+	ctx context.Context,
 	envelope *models.MetaWebhookEnvelope,
-) (parsed, skipped int) {
+) (enqueued, dup, skipped, failed int) {
 	for _, entry := range envelope.Entry {
 		for _, change := range entry.Changes {
 			if change.Field != "messages" {
@@ -206,74 +290,371 @@ func (h *MetaWebhookHandler) processEntries(
 			}
 			for i := range change.Value.Messages {
 				msg := &change.Value.Messages[i]
-				if _, ok := h.routeMessage(&change.Value, msg); ok {
-					parsed++
-				} else {
+				switch h.handleMessage(ctx, &change.Value, msg) {
+				case routeOK:
+					enqueued++
+				case routeDup:
+					dup++
+				case routeSkipped:
 					skipped++
+				case routeFailed:
+					failed++
 				}
 			}
-			// Status callbacks (delivered/read) só logados no POC.
+			// Status callbacks (delivered/read/failed) logados como telemetria.
+			// Não disparam Engine — apenas observabilidade.
 			for _, st := range change.Value.Statuses {
 				h.logger.WithFields(logrus.Fields{
 					"event":     "meta_status_callback",
 					"wamid":     st.ID,
 					"status":    st.Status,
 					"recipient": st.RecipientID,
-				}).Debug("Meta status callback (logged only in POC)")
+				}).Debug("Meta status callback")
 			}
 		}
 	}
-	return parsed, skipped
+	return enqueued, dup, skipped, failed
 }
 
-// routeMessage converte 1 mensagem Meta → UserWebhookRequest.
+// routeOutcome distingue o que aconteceu com cada mensagem inbound.
+type routeOutcome int
+
+const (
+	routeOK routeOutcome = iota
+	routeDup
+	routeSkipped
+	routeFailed
+)
+
+// handleMessage: claim atômico (SETNX) → parse → enqueue → release on failure.
 //
-// POC `feat/meta-direct-poc`: o enqueue real (RabbitMQ + Engine call) NÃO
-// está implementado ainda — é fase posterior da migração. Retornar 200 OK
-// faria Meta marcar como entregue + parar retries → silent drop. Retornar
-// erro força Meta a tentar de novo, mas isso também é ruído se a feature
-// flag estiver ativada antes da hora.
+// Ordem corrige duas condições de corrida apontadas pelo codex P1/P2:
 //
-// Solução pragmática neste POC: handler **NÃO É WIRED** ao MessageHandler
-// real até task #106 (full coverage). A função aqui apenas extrai o shape
-// (validando parsing) e devolve a `UserWebhookRequest` montado pro caller.
-// `HandleInbound` decide o status code: até implementação completa,
-// retorna 503 pra qualquer mensagem real (Meta tentará de novo), evitando
-// silent drop em produção. Quando o caller `HandleInbound` for atualizado
-// pra fazer enqueue real (task #106), trocar pra 200.
-func (h *MetaWebhookHandler) routeMessage(
+//   1. Get+Set race — duas Meta retries simultâneas observavam ambos "no key"
+//      e enqueueavam duplicado. Substituído por SETNX atômico.
+//   2. Claim-before-enqueue trap — se enqueue falhava após o set, Meta retry
+//      hitava dup e devolvia 200 (silent loss). Agora: claim primeiro, mas
+//      se enqueue falhar/skipped, dedup.Delete libera o slot pra Meta
+//      retentar até TTL.
+//
+// Trade-off: dedup ledger fica eventualmente consistente em failure paths
+// (best-effort delete). Pior caso: Delete falha → Meta retry vê dup falso
+// negativo até dedupTTL expirar (24h). Operadores podem flush via Redis
+// quando necessário.
+func (h *MetaWebhookHandler) handleMessage(
+	ctx context.Context,
+	value *models.MetaChangeValue,
+	msg *models.MetaMessage,
+) routeOutcome {
+	var (
+		claimed     bool
+		dedupKey    string
+		hasDedupKey = h.dedup != nil && msg.ID != ""
+	)
+	if hasDedupKey {
+		dedupKey = "meta:wamid:" + msg.ID
+		ok, err := h.dedup.SetNX(ctx, dedupKey, dedupValueInflight, dedupTTL)
+		if err != nil {
+			h.logger.WithError(err).WithField("wamid", msg.ID).
+				Warn("meta_inbound: SETNX failed; continuing without dedup guarantee")
+		} else if !ok {
+			// Discriminar entre in-flight (primeira request ainda processando)
+			// e done (primeira request já completou). Se in-flight, Meta deve
+			// retentar; se done, primeira request deu 200 ao Meta e dup é
+			// silent skip.
+			existing, getErr := h.dedup.Get(ctx, dedupKey)
+			if getErr != nil {
+				h.logger.WithError(getErr).WithField("wamid", msg.ID).
+					Warn("meta_inbound: dedup Get failed; treating as in-flight (will return 503)")
+				return routeFailed
+			}
+			switch existing {
+			case dedupValueDone:
+				h.logger.WithFields(logrus.Fields{
+					"event": "meta_inbound_dup",
+					"wamid": msg.ID,
+				}).Info("Meta inbound: wamid already completed, skip")
+				return routeDup
+			default: // inflight, ou outro valor → trate como in-flight
+				h.logger.WithFields(logrus.Fields{
+					"event": "meta_inbound_inflight",
+					"wamid": msg.ID,
+				}).Info("Meta inbound: wamid in-flight, return 503 pra Meta retentar")
+				return routeFailed
+			}
+		} else {
+			claimed = true
+		}
+	}
+
+	// Sentinela: na saída, claim recebe:
+	//   - routeFailed/routeSkipped → Delete (libera, Meta retry consegue replay)
+	//   - routeOK → Set("done") com mesmo TTL (upgrade in-flight → done)
+	outcome := routeFailed
+	defer func() {
+		if !claimed {
+			return
+		}
+		switch outcome {
+		case routeFailed, routeSkipped:
+			if err := h.dedup.Delete(ctx, dedupKey); err != nil {
+				h.logger.WithError(err).WithField("wamid", msg.ID).
+					Warn("meta_inbound: dedup release failed; retries blocked até TTL")
+			}
+		case routeOK:
+			if err := h.dedup.Set(ctx, dedupKey, dedupValueDone, dedupTTL); err != nil {
+				h.logger.WithError(err).WithField("wamid", msg.ID).
+					Warn("meta_inbound: dedup upgrade to done failed; duplicates can still be in-flight")
+			}
+		}
+	}()
+
+	// Parse: extrai req do tipo apropriado.
+	req, parseOutcome := h.parseMessage(value, msg)
+	if parseOutcome != routeOK {
+		outcome = parseOutcome
+		return outcome
+	}
+
+	// Wire callback apenas quando TODA a chain dispatch está pronta: URL +
+	// secret + Meta credentials. Wire parcial (URL setado mas dispatch falha
+	// auth ou Meta credentials ausentes) faz Meta receber 200 do webhook
+	// inbound e a resposta jamais chega ao cidadão.
+	if h.dispatchReady() {
+		url := h.cfg.SelfCallbackURL
+		req.CallbackURL = &url
+	} else if h.cfg.SelfCallbackURL != "" {
+		// Operator configurou intenção de Meta-direct (SelfCallbackURL setado)
+		// mas chain incompleta (secret ou Meta credentials). Refusar a enqueue
+		// pra forçar Meta retry — sem isso a mensagem fica órfã no Redis.
+		h.logger.WithFields(logrus.Fields{
+			"event":              "meta_inbound_dispatch_not_ready",
+			"wamid":              msg.ID,
+			"has_dispatch_secret": h.cfg.DispatchSecret != "",
+			"has_meta_creds":     h.cfg.SystemUserToken != "" && h.cfg.PhoneNumberID != "",
+		}).Error("Meta inbound: dispatch chain incomplete; rejecting to force Meta retry")
+		outcome = routeFailed
+		return outcome
+	}
+
+	// Enqueue real via MessageHandler (mesmo path do /api/v1/message/webhook/user).
+	if h.messageHandler == nil {
+		h.logger.WithField("wamid", msg.ID).Error("meta_inbound: messageHandler nil; cannot enqueue")
+		outcome = routeFailed
+		return outcome
+	}
+
+	enqueueCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	if _, err := h.messageHandler.EnqueueUserMessage(enqueueCtx, req, "meta_direct:"+msg.ID, nil, EnqueueOptions{TrustedInternal: true}); err != nil {
+		var inv ErrInvalidPayload
+		if errors.As(err, &inv) {
+			h.logger.WithFields(logrus.Fields{
+				"event":  "meta_inbound_invalid_payload",
+				"wamid":  msg.ID,
+				"reason": inv.Reason,
+			}).Warn("Meta inbound: payload inválido pós-parse; skip")
+			outcome = routeSkipped
+			return outcome
+		}
+		h.logger.WithError(err).WithField("wamid", msg.ID).Error("meta_inbound: enqueue failed")
+		outcome = routeFailed
+		return outcome
+	}
+
+	h.logger.WithFields(logrus.Fields{
+		"event":       "meta_inbound_enqueued",
+		"wamid":       msg.ID,
+		"user_number": req.UserNumber,
+		"type":        msg.Type,
+	}).Info("Meta inbound enqueued")
+	outcome = routeOK
+	return outcome
+}
+
+// parseMessage converte 1 mensagem Meta → UserWebhookRequest por tipo.
+//
+// Tipos suportados:
+//
+//	text                       → Message = body
+//	image / audio / video      → MessageType + Media{meta_media_id, mime, ...}
+//	location                   → MessageType=location + Media{latitude, longitude, name?, address?}
+//	interactive (button_reply / list_reply / nfm_reply) → downcast pra text com extra_metadata
+//
+// Tipos não suportados retornam (nil, routeSkipped):
+//
+//	contacts, sticker, document, reaction
+func (h *MetaWebhookHandler) parseMessage(
 	value *models.MetaChangeValue, msg *models.MetaMessage,
-) (*models.UserWebhookRequest, bool) {
-	if msg.Type != "text" {
+) (*models.UserWebhookRequest, routeOutcome) {
+	baseMeta := map[string]interface{}{
+		"source":          "meta_direct",
+		"wamid":           msg.ID,
+		"meta_timestamp":  msg.Timestamp,
+		"meta_phone_id":   value.Metadata.PhoneNumberID,
+		"meta_display_id": value.Metadata.DisplayPhoneNumber,
+	}
+
+	switch msg.Type {
+	case "text":
+		if msg.Text == nil || msg.Text.Body == "" {
+			return nil, routeSkipped
+		}
+		return &models.UserWebhookRequest{
+			UserNumber: msg.From,
+			Message:    msg.Text.Body,
+			Metadata:   baseMeta,
+		}, routeOK
+
+	case "image", "audio", "video":
+		// Media tipos: extrai meta_media_id + mime pra Engine fazer download.
+		media := mediaFromMeta(msg)
+		if media == nil {
+			h.logger.WithField("wamid", msg.ID).Warn("meta_inbound: media envelope missing id")
+			return nil, routeSkipped
+		}
+		mt := msg.Type
+		caption := ""
+		if msg.Image != nil && msg.Image.Caption != "" {
+			caption = msg.Image.Caption
+		} else if msg.Video != nil && msg.Video.Caption != "" {
+			caption = msg.Video.Caption
+		}
+		return &models.UserWebhookRequest{
+			UserNumber:  msg.From,
+			Message:     caption,
+			MessageType: &mt,
+			Media:       media,
+			Metadata:    baseMeta,
+		}, routeOK
+
+	case "location":
+		if msg.Location == nil {
+			return nil, routeSkipped
+		}
+		mt := "location"
+		media := map[string]interface{}{
+			"latitude":  msg.Location.Latitude,
+			"longitude": msg.Location.Longitude,
+		}
+		if msg.Location.Name != "" {
+			media["name"] = msg.Location.Name
+		}
+		if msg.Location.Address != "" {
+			media["address"] = msg.Location.Address
+		}
+		return &models.UserWebhookRequest{
+			UserNumber:  msg.From,
+			MessageType: &mt,
+			Media:       media,
+			Metadata:    baseMeta,
+		}, routeOK
+
+	case "interactive":
+		// button_reply / list_reply / nfm_reply (WhatsApp Flow) — downcast pra
+		// text preservando id em extra_metadata pra Engine roteiar pelo
+		// Flow registry ou pelo botão clicado.
+		body, extra := flattenInteractive(msg.Interactive)
+		if body == "" {
+			return nil, routeSkipped
+		}
+		for k, v := range extra {
+			baseMeta[k] = v
+		}
+		return &models.UserWebhookRequest{
+			UserNumber: msg.From,
+			Message:    body,
+			Metadata:   baseMeta,
+		}, routeOK
+
+	default:
 		h.logger.WithFields(logrus.Fields{
 			"event": "meta_inbound_unsupported_type",
 			"type":  msg.Type,
 			"wamid": msg.ID,
-		}).Info("Meta inbound: non-text type not yet supported")
-		return nil, false
+		}).Info("Meta inbound: type not yet supported")
+		return nil, routeSkipped
 	}
-	if msg.Text == nil || msg.Text.Body == "" {
-		h.logger.WithField("wamid", msg.ID).Warn("meta_inbound: empty text body")
-		return nil, false
-	}
+}
 
-	req := &models.UserWebhookRequest{
-		UserNumber: msg.From,
-		Message:    msg.Text.Body,
-		Metadata: map[string]interface{}{
-			"source":          "meta_direct",
-			"wamid":           msg.ID,
-			"meta_timestamp":  msg.Timestamp,
-			"meta_phone_id":   value.Metadata.PhoneNumberID,
-			"meta_display_id": value.Metadata.DisplayPhoneNumber,
-		},
+// mediaFromMeta extrai meta_media_id + mime_type dum MetaMessage cujo
+// `Type` é "image", "audio" ou "video". Retorna nil se nenhum envelope
+// tem id (payload corrompido).
+func mediaFromMeta(msg *models.MetaMessage) map[string]interface{} {
+	switch msg.Type {
+	case "image":
+		if msg.Image == nil || msg.Image.ID == "" {
+			return nil
+		}
+		return map[string]interface{}{
+			"meta_media_id": msg.Image.ID,
+			"mime_type":     msg.Image.MimeType,
+			"sha256":        msg.Image.SHA256,
+		}
+	case "audio":
+		if msg.Audio == nil || msg.Audio.ID == "" {
+			return nil
+		}
+		return map[string]interface{}{
+			"meta_media_id": msg.Audio.ID,
+			"mime_type":     msg.Audio.MimeType,
+			"sha256":        msg.Audio.SHA256,
+			"voice":         msg.Audio.Voice,
+		}
+	case "video":
+		if msg.Video == nil || msg.Video.ID == "" {
+			return nil
+		}
+		return map[string]interface{}{
+			"meta_media_id": msg.Video.ID,
+			"mime_type":     msg.Video.MimeType,
+			"sha256":        msg.Video.SHA256,
+		}
 	}
+	return nil
+}
 
-	h.logger.WithFields(logrus.Fields{
-		"event":       "meta_inbound_text_parsed",
-		"user_number": req.UserNumber,
-		"wamid":       msg.ID,
-		"text_length": len(msg.Text.Body),
-	}).Info("Meta inbound text parsed (enqueue pending task #106)")
-	return req, true
+// flattenInteractive converte interactive payload (button_reply / list_reply
+// / nfm_reply) numa string + metadata extra. Retorna ("", nil) se shape
+// desconhecido.
+func flattenInteractive(intr *models.MetaInteractive) (string, map[string]interface{}) {
+	if intr == nil {
+		return "", nil
+	}
+	switch intr.Type {
+	case "button_reply":
+		if intr.ButtonReply == nil {
+			return "", nil
+		}
+		return intr.ButtonReply.Title, map[string]interface{}{
+			"interactive_kind": "button_reply",
+			"interactive_id":   intr.ButtonReply.ID,
+		}
+	case "list_reply":
+		if intr.ListReply == nil {
+			return "", nil
+		}
+		return intr.ListReply.Title, map[string]interface{}{
+			"interactive_kind":          "list_reply",
+			"interactive_id":            intr.ListReply.ID,
+			"interactive_description":   intr.ListReply.Description,
+		}
+	case "nfm_reply":
+		// WhatsApp Flow submission. response_json carrega o form completo;
+		// downcast pra text preservando o JSON cru em metadata.
+		if intr.NFMReply == nil {
+			return "", nil
+		}
+		body := "[whatsapp_flow_submission]"
+		if intr.NFMReply.Body != "" {
+			body = intr.NFMReply.Body
+		}
+		return body, map[string]interface{}{
+			"interactive_kind":  "nfm_reply",
+			"flow_name":         intr.NFMReply.Name,
+			"flow_response_raw": intr.NFMReply.ResponseJSON,
+		}
+	}
+	return "", nil
 }

--- a/internal/handlers/meta_webhook.go
+++ b/internal/handlers/meta_webhook.go
@@ -37,6 +37,7 @@ import (
 
 	"github.com/prefeitura-rio/app-eai-agent-gateway/internal/config"
 	"github.com/prefeitura-rio/app-eai-agent-gateway/internal/models"
+	"github.com/prefeitura-rio/app-eai-agent-gateway/internal/services"
 )
 
 // MetaDedupChecker — interface mínima que o handler precisa pra idempotência.
@@ -332,24 +333,36 @@ const (
 // isFromBotItself — anti-loop guard: detecta inbound originário do próprio
 // número WABA do bot. Ocorre quando outbound wamid retorna como webhook
 // (raro em produção mas observado em sandboxes); processar como mensagem
-// cidadã faria o bot se responder em loop. Match comparing msg.From com
-// metadata.PhoneNumberID OU metadata.DisplayPhoneNumber.
-func isFromBotItself(value *models.MetaChangeValue, msg *models.MetaMessage) bool {
+// cidadã faria o bot se responder em loop.
+//
+// Comparação possível APENAS via `metadata.DisplayPhoneNumber` (E.164 sem '+',
+// mesmo formato de `msg.From`). `metadata.PhoneNumberID` é id interno da WABA
+// (numérico, "1112484171945154"), nunca bate com From. Logo é um guard
+// best-effort: se Meta entregar webhook com `DisplayPhoneNumber` vazio
+// (observado em alguns sandboxes), o guard silencia — registramos Warn pra
+// dar visibilidade ao operador.
+func (h *MetaWebhookHandler) isFromBotItself(value *models.MetaChangeValue, msg *models.MetaMessage) bool {
 	if msg == nil || msg.From == "" {
 		return false
 	}
-	// PhoneNumberID é o id interno da WABA (não bate com From, que é o
-	// número E.164 sem '+'). DisplayPhoneNumber é o número formatado pra
-	// display ("5521989091014" ou "55 21 9 8909-1014"). Normalize ambos pra
-	// dígitos antes de comparar.
 	from := normalizeDigits(msg.From)
 	if from == "" {
 		return false
 	}
-	if normalizeDigits(value.Metadata.DisplayPhoneNumber) == from {
-		return true
+	displayDigits := normalizeDigits(value.Metadata.DisplayPhoneNumber)
+	if displayDigits == "" {
+		// Sandbox/edge case: Meta omitiu DisplayPhoneNumber. Sem ele não
+		// dá pra comparar E.164 confiável (PhoneNumberID é id interno).
+		// Log Warn pra operador notar se isso virar comum em prod.
+		h.logger.WithFields(logrus.Fields{
+			"event":            "meta_inbound_anti_loop_degraded",
+			"wamid":            msg.ID,
+			"phone_number_id":  value.Metadata.PhoneNumberID,
+			"reason":           "DisplayPhoneNumber vazio, guard desativado pra essa msg",
+		}).Warn("meta_inbound: anti-loop guard cannot compare; allowing message through")
+		return false
 	}
-	return false
+	return displayDigits == from
 }
 
 // normalizeDigits remove tudo exceto dígitos. "55 21 9 8909-1014" → "5521989091014".
@@ -395,7 +408,7 @@ func (h *MetaWebhookHandler) handleMessage(
 ) routeOutcome {
 	// Anti-loop guard: dropar mensagens originadas do próprio bot. Evita
 	// cascade bot→bot caso outbound vire inbound por erro de config Meta.
-	if isFromBotItself(value, msg) {
+	if h.isFromBotItself(value, msg) {
 		h.logger.WithFields(logrus.Fields{
 			"event":     "meta_inbound_self_loop_drop",
 			"wamid":     msg.ID,
@@ -422,6 +435,19 @@ func (h *MetaWebhookHandler) handleMessage(
 			// retentar; se done, primeira request deu 200 ao Meta e dup é
 			// silent skip.
 			existing, getErr := h.dedup.Get(ctx, dedupKey)
+			if errors.Is(getErr, services.ErrKeyNotFound) {
+				// Race: SETNX falhou mas o Get retornou not-found. Significa
+				// que a chave foi evicted (Redis LRU pressure) ou TTL expirou
+				// entre as duas chamadas. Comportamento semanticamente correto
+				// é assumir "sem claim" — retornar routeFailed faria Meta
+				// retentar desnecessariamente. Mas como NÃO temos a claim
+				// (SETNX deu false), seguir o fluxo de enqueue criaria
+				// inconsistência. Trate como in-flight; o Meta retry resolve
+				// no próximo round com SETNX limpo.
+				h.logger.WithField("wamid", msg.ID).
+					Warn("meta_inbound: SETNX false but Get not-found (Redis LRU evict/race); will return 503 for Meta retry")
+				return routeFailed
+			}
 			if getErr != nil {
 				h.logger.WithError(getErr).WithField("wamid", msg.ID).
 					Warn("meta_inbound: dedup Get failed; treating as in-flight (will return 503)")

--- a/internal/handlers/meta_webhook_test.go
+++ b/internal/handlers/meta_webhook_test.go
@@ -1,0 +1,328 @@
+package handlers
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	stdio "io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/sirupsen/logrus"
+
+	"github.com/prefeitura-rio/app-eai-agent-gateway/internal/config"
+)
+
+// newTestHandler — helper pra testes; AppSecret/VerifyToken fixos.
+func newTestHandler(t *testing.T) *MetaWebhookHandler {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	logger := logrus.New()
+	logger.SetOutput(stdio.Discard)
+	cfg := &config.MetaConfig{
+		Enabled:         true,
+		VerifyToken:     "test-verify-token",
+		AppSecret:       "test-app-secret",
+		PhoneNumberID:   "123",
+		SystemUserToken: "tok",
+		GraphAPIVersion: "v21.0",
+	}
+	return NewMetaWebhookHandler(cfg, nil, logger)
+}
+
+// signBody helper — produz "sha256=<hex>".
+func signBody(t *testing.T, body []byte, secret string) string {
+	t.Helper()
+	mac := hmac.New(sha256.New, []byte(secret))
+	_, _ = mac.Write(body)
+	return "sha256=" + hex.EncodeToString(mac.Sum(nil))
+}
+
+// ────────────────────────────────────────────────────────────
+// HandleVerify
+// ────────────────────────────────────────────────────────────
+
+func TestVerify_HappyPath(t *testing.T) {
+	h := newTestHandler(t)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet,
+		"/meta/webhook?hub.mode=subscribe&hub.verify_token=test-verify-token&hub.challenge=xyz789", nil)
+
+	h.HandleVerify(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if got := w.Body.String(); got != "xyz789" {
+		t.Errorf("expected body=challenge, got %q", got)
+	}
+}
+
+func TestVerify_WrongMode(t *testing.T) {
+	h := newTestHandler(t)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet,
+		"/meta/webhook?hub.mode=unsubscribe&hub.verify_token=test-verify-token&hub.challenge=x", nil)
+
+	h.HandleVerify(c)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("expected 403, got %d", w.Code)
+	}
+}
+
+func TestVerify_FailsClosedWhenTokenUnset(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	logger := logrus.New()
+	logger.SetOutput(stdio.Discard)
+	// VerifyToken empty na config — request sem token também é empty,
+	// mas deve falhar (fail-closed, codex P2).
+	h := NewMetaWebhookHandler(&config.MetaConfig{VerifyToken: ""}, nil, logger)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet,
+		"/meta/webhook?hub.mode=subscribe&hub.challenge=open", nil)
+
+	h.HandleVerify(c)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("expected 403 fail-closed when token unset, got %d", w.Code)
+	}
+}
+
+func TestVerify_WrongToken(t *testing.T) {
+	h := newTestHandler(t)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet,
+		"/meta/webhook?hub.mode=subscribe&hub.verify_token=ATTACKER&hub.challenge=x", nil)
+
+	h.HandleVerify(c)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("expected 403, got %d", w.Code)
+	}
+}
+
+// ────────────────────────────────────────────────────────────
+// HandleInbound — HMAC
+// ────────────────────────────────────────────────────────────
+
+func TestInbound_MissingSignature(t *testing.T) {
+	h := newTestHandler(t)
+	body := []byte(`{"object":"whatsapp_business_account","entry":[]}`)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/meta/webhook", bytes.NewReader(body))
+
+	h.HandleInbound(c)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401 missing signature, got %d", w.Code)
+	}
+}
+
+func TestInbound_InvalidSignature(t *testing.T) {
+	h := newTestHandler(t)
+	body := []byte(`{"object":"whatsapp_business_account","entry":[]}`)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/meta/webhook", bytes.NewReader(body))
+	c.Request.Header.Set("X-Hub-Signature-256", "sha256=deadbeef")
+
+	h.HandleInbound(c)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401 invalid signature, got %d", w.Code)
+	}
+}
+
+func TestInbound_ValidSignatureEmptyEnvelope(t *testing.T) {
+	h := newTestHandler(t)
+	body := []byte(`{"object":"whatsapp_business_account","entry":[]}`)
+	sig := signBody(t, body, "test-app-secret")
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/meta/webhook", bytes.NewReader(body))
+	c.Request.Header.Set("X-Hub-Signature-256", sig)
+
+	h.HandleInbound(c)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestInbound_NonWhatsappObject(t *testing.T) {
+	h := newTestHandler(t)
+	body := []byte(`{"object":"instagram","entry":[]}`)
+	sig := signBody(t, body, "test-app-secret")
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/meta/webhook", bytes.NewReader(body))
+	c.Request.Header.Set("X-Hub-Signature-256", sig)
+
+	h.HandleInbound(c)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 (ignored), got %d", w.Code)
+	}
+	var resp map[string]interface{}
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["status"] != "ignored" {
+		t.Errorf("expected status=ignored, got %v", resp)
+	}
+}
+
+func TestInbound_UnsupportedTypeAlsoReturns503(t *testing.T) {
+	h := newTestHandler(t)
+	// image type não suportado no POC; deve retornar 503 (não 200) pra
+	// forçar Meta retry. Sem isso = silent drop (codex P2 round 2).
+	payload := `{
+	  "object": "whatsapp_business_account",
+	  "entry": [{
+	    "id": "WABA_ID",
+	    "changes": [{
+	      "field": "messages",
+	      "value": {
+	        "messaging_product": "whatsapp",
+	        "metadata": {"display_phone_number": "21", "phone_number_id": "1"},
+	        "messages": [{
+	          "from": "5500",
+	          "id": "wamid.IMG",
+	          "timestamp": "1779225000",
+	          "type": "image",
+	          "image": {"id": "media-id-xxx", "mime_type": "image/jpeg"}
+	        }]
+	      }
+	    }]
+	  }]
+	}`
+	body := []byte(payload)
+	sig := signBody(t, body, "test-app-secret")
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/meta/webhook", bytes.NewReader(body))
+	c.Request.Header.Set("X-Hub-Signature-256", sig)
+
+	h.HandleInbound(c)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected 503 (unsupported type), got %d", w.Code)
+	}
+}
+
+func TestInbound_StatusCallbackReturns200(t *testing.T) {
+	h := newTestHandler(t)
+	// Status callbacks só (sem mensagens) — não há trabalho pendente,
+	// 200 OK é correto (Meta não precisa retentar).
+	payload := `{
+	  "object": "whatsapp_business_account",
+	  "entry": [{
+	    "id": "WABA_ID",
+	    "changes": [{
+	      "field": "messages",
+	      "value": {
+	        "messaging_product": "whatsapp",
+	        "metadata": {"display_phone_number": "21", "phone_number_id": "1"},
+	        "statuses": [{
+	          "id": "wamid.X",
+	          "status": "delivered",
+	          "timestamp": "1779225000",
+	          "recipient_id": "5500"
+	        }]
+	      }
+	    }]
+	  }]
+	}`
+	body := []byte(payload)
+	sig := signBody(t, body, "test-app-secret")
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/meta/webhook", bytes.NewReader(body))
+	c.Request.Header.Set("X-Hub-Signature-256", sig)
+
+	h.HandleInbound(c)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 (status-only), got %d body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestInbound_TextMessage_Returns503UntilEnqueueWired(t *testing.T) {
+	h := newTestHandler(t)
+	payload := `{
+	  "object": "whatsapp_business_account",
+	  "entry": [{
+	    "id": "WABA_ID",
+	    "changes": [{
+	      "field": "messages",
+	      "value": {
+	        "messaging_product": "whatsapp",
+	        "metadata": {"display_phone_number": "21989091014", "phone_number_id": "1121997777663061"},
+	        "contacts": [{"wa_id": "5500000000000", "profile": {"name": "Test"}}],
+	        "messages": [{
+	          "from": "5500000000000",
+	          "id": "wamid.TEST",
+	          "timestamp": "1779225000",
+	          "type": "text",
+	          "text": {"body": "Olá bot"}
+	        }]
+	      }
+	    }]
+	  }]
+	}`
+	body := []byte(payload)
+	sig := signBody(t, body, "test-app-secret")
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/meta/webhook", bytes.NewReader(body))
+	c.Request.Header.Set("X-Hub-Signature-256", sig)
+
+	h.HandleInbound(c)
+
+	// POC: text parseado deve retornar 503 (Meta retry) enquanto enqueue
+	// real não está wired (task #106). Sem isso, mensagem seria silent-drop.
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected 503 (POC parse-only), got %d body=%s", w.Code, w.Body.String())
+	}
+	var resp map[string]interface{}
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["status"] != "not_ready" {
+		t.Errorf("expected status=not_ready, got %v", resp["status"])
+	}
+}
+
+// ────────────────────────────────────────────────────────────
+// validateSignature — edge cases
+// ────────────────────────────────────────────────────────────
+
+func TestValidateSignature_NoPrefix(t *testing.T) {
+	h := newTestHandler(t)
+	if h.validateSignature("nothex", []byte("body")) {
+		t.Error("expected false for header without sha256= prefix")
+	}
+}
+
+func TestValidateSignature_EmptySecretFailsClosed(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	logger := logrus.New()
+	logger.SetOutput(stdio.Discard)
+	h := NewMetaWebhookHandler(
+		&config.MetaConfig{AppSecret: ""},
+		nil, logger,
+	)
+	// Mesmo com header válido, sem AppSecret deve falhar.
+	body := []byte("body")
+	sig := signBody(t, body, "any")
+	if h.validateSignature(sig, body) {
+		t.Error("expected false when AppSecret empty (fail-closed)")
+	}
+}
+

--- a/internal/handlers/meta_webhook_test.go
+++ b/internal/handlers/meta_webhook_test.go
@@ -2,20 +2,152 @@ package handlers
 
 import (
 	"bytes"
+	"context"
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	stdio "io"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
 
 	"github.com/prefeitura-rio/app-eai-agent-gateway/internal/config"
+	"github.com/prefeitura-rio/app-eai-agent-gateway/internal/models"
 )
+
+// ─── Mocks ───────────────────────────────────────────────────────────────
+
+// mockEnqueuer captura chamadas EnqueueUserMessage pra asserir o que foi
+// publicado. shouldFail força erro pra testar o path failed.
+type mockEnqueuer struct {
+	mu          sync.Mutex
+	calls       []models.UserWebhookRequest
+	shouldFail  bool
+	failInvalid bool
+}
+
+func (m *mockEnqueuer) EnqueueUserMessage(
+	_ context.Context, req *models.UserWebhookRequest,
+	_ string, _ map[string]interface{}, _ EnqueueOptions,
+) (*EnqueueResult, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if req != nil {
+		m.calls = append(m.calls, *req)
+	}
+	if m.failInvalid {
+		return nil, ErrInvalidPayload{Reason: "test invalid"}
+	}
+	if m.shouldFail {
+		return nil, errors.New("enqueue mock failure")
+	}
+	return &EnqueueResult{MessageID: "test-msg-id", Status: "processing"}, nil
+}
+
+func (m *mockEnqueuer) callCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.calls)
+}
+
+func (m *mockEnqueuer) lastCall() *models.UserWebhookRequest {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if len(m.calls) == 0 {
+		return nil
+	}
+	r := m.calls[len(m.calls)-1]
+	return &r
+}
+
+// mockDedup implementa MetaDedupChecker em memória com semântica SETNX +
+// Delete. setNXErr força erro no SetNX (pra testar fallback non-atomic).
+type mockDedup struct {
+	mu       sync.Mutex
+	store    map[string]string
+	setNXErr error
+	delErr   error
+}
+
+func newMockDedup() *mockDedup {
+	return &mockDedup{store: map[string]string{}}
+}
+
+func (m *mockDedup) SetNX(_ context.Context, key string, value string, _ time.Duration) (bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.setNXErr != nil {
+		return false, m.setNXErr
+	}
+	if _, exists := m.store[key]; exists {
+		return false, nil
+	}
+	m.store[key] = value
+	return true, nil
+}
+
+func (m *mockDedup) Get(_ context.Context, key string) (string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if v, ok := m.store[key]; ok {
+		return v, nil
+	}
+	return "", nil
+}
+
+func (m *mockDedup) Set(_ context.Context, key string, value string, _ time.Duration) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.store[key] = value
+	return nil
+}
+
+func (m *mockDedup) Delete(_ context.Context, key string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.delErr != nil {
+		return m.delErr
+	}
+	delete(m.store, key)
+	return nil
+}
+
+func (m *mockDedup) putValue(key, val string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.store[key] = val
+}
+
+func (m *mockDedup) has(key string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	_, ok := m.store[key]
+	return ok
+}
+
+// newTestHandlerWithDeps — helper que aceita mocks de enqueue + dedup.
+func newTestHandlerWithDeps(t *testing.T, enq MessageEnqueuer, dedup MetaDedupChecker) *MetaWebhookHandler {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	logger := logrus.New()
+	logger.SetOutput(stdio.Discard)
+	cfg := &config.MetaConfig{
+		Enabled:         true,
+		VerifyToken:     "test-verify-token",
+		AppSecret:       "test-app-secret",
+		PhoneNumberID:   "123",
+		SystemUserToken: "tok",
+		GraphAPIVersion: "v21.0",
+	}
+	return NewMetaWebhookHandler(cfg, enq, dedup, logger)
+}
 
 // newTestHandler — helper pra testes; AppSecret/VerifyToken fixos.
 func newTestHandler(t *testing.T) *MetaWebhookHandler {
@@ -31,7 +163,7 @@ func newTestHandler(t *testing.T) *MetaWebhookHandler {
 		SystemUserToken: "tok",
 		GraphAPIVersion: "v21.0",
 	}
-	return NewMetaWebhookHandler(cfg, nil, logger)
+	return NewMetaWebhookHandler(cfg, nil, nil, logger)
 }
 
 // signBody helper — produz "sha256=<hex>".
@@ -83,7 +215,7 @@ func TestVerify_FailsClosedWhenTokenUnset(t *testing.T) {
 	logger.SetOutput(stdio.Discard)
 	// VerifyToken empty na config — request sem token também é empty,
 	// mas deve falhar (fail-closed, codex P2).
-	h := NewMetaWebhookHandler(&config.MetaConfig{VerifyToken: ""}, nil, logger)
+	h := NewMetaWebhookHandler(&config.MetaConfig{VerifyToken: ""}, nil, nil, logger)
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
 	c.Request = httptest.NewRequest(http.MethodGet,
@@ -180,10 +312,11 @@ func TestInbound_NonWhatsappObject(t *testing.T) {
 	}
 }
 
-func TestInbound_UnsupportedTypeAlsoReturns503(t *testing.T) {
-	h := newTestHandler(t)
-	// image type não suportado no POC; deve retornar 503 (não 200) pra
-	// forçar Meta retry. Sem isso = silent drop (codex P2 round 2).
+func TestInbound_UnsupportedTypeReturns503(t *testing.T) {
+	// Sticker não é suportado no parser — handler retorna routeSkipped que
+	// vira 503 pra Meta retentar. Sem isso = silent drop (codex P2 round 2).
+	enq := &mockEnqueuer{}
+	h := newTestHandlerWithDeps(t, enq, newMockDedup())
 	payload := `{
 	  "object": "whatsapp_business_account",
 	  "entry": [{
@@ -195,10 +328,10 @@ func TestInbound_UnsupportedTypeAlsoReturns503(t *testing.T) {
 	        "metadata": {"display_phone_number": "21", "phone_number_id": "1"},
 	        "messages": [{
 	          "from": "5500",
-	          "id": "wamid.IMG",
+	          "id": "wamid.STK",
 	          "timestamp": "1779225000",
-	          "type": "image",
-	          "image": {"id": "media-id-xxx", "mime_type": "image/jpeg"}
+	          "type": "sticker",
+	          "sticker": {"id": "stk-1", "mime_type": "image/webp"}
 	        }]
 	      }
 	    }]
@@ -210,11 +343,12 @@ func TestInbound_UnsupportedTypeAlsoReturns503(t *testing.T) {
 	c, _ := gin.CreateTestContext(w)
 	c.Request = httptest.NewRequest(http.MethodPost, "/meta/webhook", bytes.NewReader(body))
 	c.Request.Header.Set("X-Hub-Signature-256", sig)
-
 	h.HandleInbound(c)
-
 	if w.Code != http.StatusServiceUnavailable {
-		t.Errorf("expected 503 (unsupported type), got %d", w.Code)
+		t.Errorf("expected 503 (unsupported sticker), got %d", w.Code)
+	}
+	if enq.callCount() != 0 {
+		t.Errorf("expected zero enqueue calls (unsupported), got %d", enq.callCount())
 	}
 }
 
@@ -255,8 +389,9 @@ func TestInbound_StatusCallbackReturns200(t *testing.T) {
 	}
 }
 
-func TestInbound_TextMessage_Returns503UntilEnqueueWired(t *testing.T) {
-	h := newTestHandler(t)
+func TestInbound_TextMessage_EnqueuesAndReturns200(t *testing.T) {
+	enq := &mockEnqueuer{}
+	h := newTestHandlerWithDeps(t, enq, newMockDedup())
 	payload := `{
 	  "object": "whatsapp_business_account",
 	  "entry": [{
@@ -284,18 +419,421 @@ func TestInbound_TextMessage_Returns503UntilEnqueueWired(t *testing.T) {
 	c, _ := gin.CreateTestContext(w)
 	c.Request = httptest.NewRequest(http.MethodPost, "/meta/webhook", bytes.NewReader(body))
 	c.Request.Header.Set("X-Hub-Signature-256", sig)
-
 	h.HandleInbound(c)
 
-	// POC: text parseado deve retornar 503 (Meta retry) enquanto enqueue
-	// real não está wired (task #106). Sem isso, mensagem seria silent-drop.
-	if w.Code != http.StatusServiceUnavailable {
-		t.Errorf("expected 503 (POC parse-only), got %d body=%s", w.Code, w.Body.String())
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 (enqueued), got %d body=%s", w.Code, w.Body.String())
 	}
-	var resp map[string]interface{}
-	_ = json.Unmarshal(w.Body.Bytes(), &resp)
-	if resp["status"] != "not_ready" {
-		t.Errorf("expected status=not_ready, got %v", resp["status"])
+	if enq.callCount() != 1 {
+		t.Fatalf("expected 1 enqueue call, got %d", enq.callCount())
+	}
+	req := enq.lastCall()
+	if req.UserNumber != "5500000000000" {
+		t.Errorf("expected UserNumber=5500000000000, got %q", req.UserNumber)
+	}
+	if req.Message != "Olá bot" {
+		t.Errorf("expected Message=Olá bot, got %q", req.Message)
+	}
+	if req.Metadata["wamid"] != "wamid.TEST" {
+		t.Errorf("expected metadata.wamid=wamid.TEST, got %v", req.Metadata["wamid"])
+	}
+}
+
+func TestInbound_EnqueueFailureReturns503(t *testing.T) {
+	enq := &mockEnqueuer{shouldFail: true}
+	h := newTestHandlerWithDeps(t, enq, newMockDedup())
+	payload := `{
+	  "object": "whatsapp_business_account",
+	  "entry": [{
+	    "id": "WABA_ID",
+	    "changes": [{
+	      "field": "messages",
+	      "value": {
+	        "messaging_product": "whatsapp",
+	        "metadata": {"display_phone_number": "21", "phone_number_id": "1"},
+	        "messages": [{
+	          "from": "5500",
+	          "id": "wamid.FAIL",
+	          "timestamp": "1",
+	          "type": "text",
+	          "text": {"body": "x"}
+	        }]
+	      }
+	    }]
+	  }]
+	}`
+	body := []byte(payload)
+	sig := signBody(t, body, "test-app-secret")
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/meta/webhook", bytes.NewReader(body))
+	c.Request.Header.Set("X-Hub-Signature-256", sig)
+	h.HandleInbound(c)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected 503 (enqueue failure), got %d", w.Code)
+	}
+}
+
+func TestInbound_DedupSkipsSecondCall(t *testing.T) {
+	enq := &mockEnqueuer{}
+	dedup := newMockDedup()
+	h := newTestHandlerWithDeps(t, enq, dedup)
+	payload := `{
+	  "object": "whatsapp_business_account",
+	  "entry": [{
+	    "id": "WABA_ID",
+	    "changes": [{
+	      "field": "messages",
+	      "value": {
+	        "messaging_product": "whatsapp",
+	        "metadata": {"display_phone_number": "21", "phone_number_id": "1"},
+	        "messages": [{
+	          "from": "5500",
+	          "id": "wamid.DUP",
+	          "timestamp": "1",
+	          "type": "text",
+	          "text": {"body": "dup test"}
+	        }]
+	      }
+	    }]
+	  }]
+	}`
+	body := []byte(payload)
+	sig := signBody(t, body, "test-app-secret")
+
+	// Primeira chamada — enqueue + dedup register
+	{
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest(http.MethodPost, "/meta/webhook", bytes.NewReader(body))
+		c.Request.Header.Set("X-Hub-Signature-256", sig)
+		h.HandleInbound(c)
+		if w.Code != http.StatusOK {
+			t.Fatalf("first call expected 200, got %d", w.Code)
+		}
+	}
+	// Segunda — dedup hit, sem nova enqueue
+	{
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest(http.MethodPost, "/meta/webhook", bytes.NewReader(body))
+		c.Request.Header.Set("X-Hub-Signature-256", sig)
+		h.HandleInbound(c)
+		if w.Code != http.StatusOK {
+			t.Fatalf("second (dup) call expected 200, got %d", w.Code)
+		}
+	}
+	if enq.callCount() != 1 {
+		t.Errorf("expected 1 enqueue (dup skipped), got %d", enq.callCount())
+	}
+}
+
+func TestInbound_ImageMessage_ExtractsMedia(t *testing.T) {
+	enq := &mockEnqueuer{}
+	h := newTestHandlerWithDeps(t, enq, newMockDedup())
+	payload := `{
+	  "object": "whatsapp_business_account",
+	  "entry": [{
+	    "id": "WABA_ID",
+	    "changes": [{
+	      "field": "messages",
+	      "value": {
+	        "messaging_product": "whatsapp",
+	        "metadata": {"display_phone_number": "21", "phone_number_id": "1"},
+	        "messages": [{
+	          "from": "5500",
+	          "id": "wamid.IMG",
+	          "timestamp": "1",
+	          "type": "image",
+	          "image": {"id": "meta-media-123", "mime_type": "image/jpeg", "sha256": "abc"}
+	        }]
+	      }
+	    }]
+	  }]
+	}`
+	body := []byte(payload)
+	sig := signBody(t, body, "test-app-secret")
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/meta/webhook", bytes.NewReader(body))
+	c.Request.Header.Set("X-Hub-Signature-256", sig)
+	h.HandleInbound(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	req := enq.lastCall()
+	if req == nil {
+		t.Fatal("expected enqueue call, got none")
+	}
+	if req.MessageType == nil || *req.MessageType != "image" {
+		t.Errorf("expected MessageType=image, got %v", req.MessageType)
+	}
+	if req.Media["meta_media_id"] != "meta-media-123" {
+		t.Errorf("expected meta_media_id=meta-media-123, got %v", req.Media["meta_media_id"])
+	}
+}
+
+func TestInbound_LocationMessage_ExtractsCoords(t *testing.T) {
+	enq := &mockEnqueuer{}
+	h := newTestHandlerWithDeps(t, enq, newMockDedup())
+	payload := `{
+	  "object": "whatsapp_business_account",
+	  "entry": [{
+	    "id": "WABA_ID",
+	    "changes": [{
+	      "field": "messages",
+	      "value": {
+	        "messaging_product": "whatsapp",
+	        "metadata": {"display_phone_number": "21", "phone_number_id": "1"},
+	        "messages": [{
+	          "from": "5500",
+	          "id": "wamid.LOC",
+	          "timestamp": "1",
+	          "type": "location",
+	          "location": {"latitude": -22.9, "longitude": -43.2, "name": "Centro", "address": "RJ"}
+	        }]
+	      }
+	    }]
+	  }]
+	}`
+	body := []byte(payload)
+	sig := signBody(t, body, "test-app-secret")
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/meta/webhook", bytes.NewReader(body))
+	c.Request.Header.Set("X-Hub-Signature-256", sig)
+	h.HandleInbound(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	req := enq.lastCall()
+	if req == nil {
+		t.Fatal("expected enqueue call")
+	}
+	if req.MessageType == nil || *req.MessageType != "location" {
+		t.Errorf("expected MessageType=location, got %v", req.MessageType)
+	}
+	if got := req.Media["latitude"]; got != float64(-22.9) {
+		t.Errorf("expected latitude=-22.9, got %v", got)
+	}
+}
+
+func TestInbound_InteractiveButtonReply_DowncastsToText(t *testing.T) {
+	enq := &mockEnqueuer{}
+	h := newTestHandlerWithDeps(t, enq, newMockDedup())
+	payload := `{
+	  "object": "whatsapp_business_account",
+	  "entry": [{
+	    "id": "WABA_ID",
+	    "changes": [{
+	      "field": "messages",
+	      "value": {
+	        "messaging_product": "whatsapp",
+	        "metadata": {"display_phone_number": "21", "phone_number_id": "1"},
+	        "messages": [{
+	          "from": "5500",
+	          "id": "wamid.BTN",
+	          "timestamp": "1",
+	          "type": "interactive",
+	          "interactive": {
+	            "type": "button_reply",
+	            "button_reply": {"id": "btn-1", "title": "Sim"}
+	          }
+	        }]
+	      }
+	    }]
+	  }]
+	}`
+	body := []byte(payload)
+	sig := signBody(t, body, "test-app-secret")
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/meta/webhook", bytes.NewReader(body))
+	c.Request.Header.Set("X-Hub-Signature-256", sig)
+	h.HandleInbound(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	req := enq.lastCall()
+	if req == nil || req.Message != "Sim" {
+		t.Errorf("expected Message=Sim, got %v", req)
+	}
+	if req.Metadata["interactive_kind"] != "button_reply" {
+		t.Errorf("expected interactive_kind=button_reply, got %v", req.Metadata["interactive_kind"])
+	}
+	if req.Metadata["interactive_id"] != "btn-1" {
+		t.Errorf("expected interactive_id=btn-1, got %v", req.Metadata["interactive_id"])
+	}
+}
+
+func TestInbound_InFlightClaimReturns503(t *testing.T) {
+	// Codex P2: claim adquirida mas ainda não-done. Dup deve retornar 503
+	// pra Meta retentar (vs 200 que silenciaria a entrega).
+	enq := &mockEnqueuer{}
+	dedup := newMockDedup()
+	dedup.putValue("meta:wamid:wamid.INFLIGHT", "inflight") // simula primeira req in-progress
+	h := newTestHandlerWithDeps(t, enq, dedup)
+	payload := `{
+	  "object": "whatsapp_business_account",
+	  "entry": [{"id": "WABA_ID", "changes": [{"field": "messages",
+	    "value": {"messaging_product":"whatsapp",
+	      "metadata":{"display_phone_number":"21","phone_number_id":"1"},
+	      "messages":[{"from":"5500","id":"wamid.INFLIGHT","timestamp":"1","type":"text","text":{"body":"x"}}]
+	    }}]}]}`
+	body := []byte(payload)
+	sig := signBody(t, body, "test-app-secret")
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/meta/webhook", bytes.NewReader(body))
+	c.Request.Header.Set("X-Hub-Signature-256", sig)
+	h.HandleInbound(c)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected 503 (in-flight → retry), got %d", w.Code)
+	}
+}
+
+func TestInbound_CompletedDupReturns200(t *testing.T) {
+	// Mesma claim mas valor "done" → 200 (silent skip, primeira request
+	// já completou e devolveu 200 ao Meta).
+	enq := &mockEnqueuer{}
+	dedup := newMockDedup()
+	dedup.putValue("meta:wamid:wamid.DONE", "done")
+	h := newTestHandlerWithDeps(t, enq, dedup)
+	payload := `{
+	  "object": "whatsapp_business_account",
+	  "entry": [{"id": "WABA_ID", "changes": [{"field": "messages",
+	    "value": {"messaging_product":"whatsapp",
+	      "metadata":{"display_phone_number":"21","phone_number_id":"1"},
+	      "messages":[{"from":"5500","id":"wamid.DONE","timestamp":"1","type":"text","text":{"body":"x"}}]
+	    }}]}]}`
+	body := []byte(payload)
+	sig := signBody(t, body, "test-app-secret")
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/meta/webhook", bytes.NewReader(body))
+	c.Request.Header.Set("X-Hub-Signature-256", sig)
+	h.HandleInbound(c)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 (done → silent dup), got %d", w.Code)
+	}
+	if enq.callCount() != 0 {
+		t.Errorf("expected zero enqueue (already done), got %d", enq.callCount())
+	}
+}
+
+func TestInbound_EnqueueFailureReleasesDedupClaim(t *testing.T) {
+	// Codex P1: claim antes do enqueue cria silent loss se enqueue falha.
+	// Fix: liberar a claim quando outcome=failed/skipped, pra Meta retry
+	// conseguir reprocessar.
+	enq := &mockEnqueuer{shouldFail: true}
+	dedup := newMockDedup()
+	h := newTestHandlerWithDeps(t, enq, dedup)
+	payload := `{
+	  "object": "whatsapp_business_account",
+	  "entry": [{
+	    "id": "WABA_ID",
+	    "changes": [{
+	      "field": "messages",
+	      "value": {
+	        "messaging_product": "whatsapp",
+	        "metadata": {"display_phone_number": "21", "phone_number_id": "1"},
+	        "messages": [{"from": "5500", "id": "wamid.RELEASE", "timestamp": "1", "type": "text", "text": {"body": "x"}}]
+	      }
+	    }]
+	  }]
+	}`
+	body := []byte(payload)
+	sig := signBody(t, body, "test-app-secret")
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/meta/webhook", bytes.NewReader(body))
+	c.Request.Header.Set("X-Hub-Signature-256", sig)
+	h.HandleInbound(c)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected 503 (enqueue failed), got %d", w.Code)
+	}
+	// Claim deve ter sido liberada — Meta retry verá ledger limpo.
+	if dedup.has("meta:wamid:wamid.RELEASE") {
+		t.Error("expected dedup claim to be released after enqueue failure; Meta retry would be silently skipped")
+	}
+}
+
+func TestInbound_DedupSetNXErrorContinuesWithoutBlock(t *testing.T) {
+	// SETNX retornando erro não deve bloquear o handler — só logamos e
+	// continuamos sem garantia de dedup. Resilience >	atomicidade quando
+	// Redis flapping.
+	enq := &mockEnqueuer{}
+	dedup := newMockDedup()
+	dedup.setNXErr = errors.New("redis down")
+	h := newTestHandlerWithDeps(t, enq, dedup)
+	payload := `{
+	  "object": "whatsapp_business_account",
+	  "entry": [{
+	    "id": "WABA_ID",
+	    "changes": [{
+	      "field": "messages",
+	      "value": {
+	        "messaging_product": "whatsapp",
+	        "metadata": {"display_phone_number": "21", "phone_number_id": "1"},
+	        "messages": [{"from": "5500", "id": "wamid.SETNXERR", "timestamp": "1", "type": "text", "text": {"body": "x"}}]
+	      }
+	    }]
+	  }]
+	}`
+	body := []byte(payload)
+	sig := signBody(t, body, "test-app-secret")
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/meta/webhook", bytes.NewReader(body))
+	c.Request.Header.Set("X-Hub-Signature-256", sig)
+	h.HandleInbound(c)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 (degraded dedup), got %d", w.Code)
+	}
+	if enq.callCount() != 1 {
+		t.Errorf("expected 1 enqueue (without dedup), got %d", enq.callCount())
+	}
+}
+
+func TestInbound_NoMessageHandlerReturns503(t *testing.T) {
+	// Sem MessageEnqueuer wired, text também cai em routeFailed → 503.
+	gin.SetMode(gin.TestMode)
+	logger := logrus.New()
+	logger.SetOutput(stdio.Discard)
+	cfg := &config.MetaConfig{
+		Enabled: true, VerifyToken: "t", AppSecret: "test-app-secret",
+		PhoneNumberID: "1", SystemUserToken: "tok", GraphAPIVersion: "v21.0",
+	}
+	h := NewMetaWebhookHandler(cfg, nil, newMockDedup(), logger)
+	payload := `{
+	  "object": "whatsapp_business_account",
+	  "entry": [{
+	    "id": "WABA_ID",
+	    "changes": [{
+	      "field": "messages",
+	      "value": {
+	        "messaging_product": "whatsapp",
+	        "metadata": {"display_phone_number": "21", "phone_number_id": "1"},
+	        "messages": [{"from": "5500", "id": "wamid.NIL", "timestamp": "1", "type": "text", "text": {"body": "x"}}]
+	      }
+	    }]
+	  }]
+	}`
+	body := []byte(payload)
+	sig := signBody(t, body, "test-app-secret")
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/meta/webhook", bytes.NewReader(body))
+	c.Request.Header.Set("X-Hub-Signature-256", sig)
+	h.HandleInbound(c)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected 503 (no enqueuer), got %d", w.Code)
 	}
 }
 
@@ -316,7 +854,7 @@ func TestValidateSignature_EmptySecretFailsClosed(t *testing.T) {
 	logger.SetOutput(stdio.Discard)
 	h := NewMetaWebhookHandler(
 		&config.MetaConfig{AppSecret: ""},
-		nil, logger,
+		nil, nil, logger,
 	)
 	// Mesmo com header válido, sem AppSecret deve falhar.
 	body := []byte("body")

--- a/internal/handlers/meta_webhook_test.go
+++ b/internal/handlers/meta_webhook_test.go
@@ -145,6 +145,12 @@ func newTestHandlerWithDeps(t *testing.T, enq MessageEnqueuer, dedup MetaDedupCh
 		PhoneNumberID:   "123",
 		SystemUserToken: "tok",
 		GraphAPIVersion: "v21.0",
+		// dispatchReady() exige chain completa pra wire callback nas mensagens
+		// enfileiradas. Sem isso o webhook devolve 503 (fail-loud em vez de
+		// silenciar respostas órfãs). Helpers expõem chain válida por default;
+		// tests específicos de "chain incompleta" sobrescrevem antes de chamar.
+		SelfCallbackURL: "https://test/callback",
+		DispatchSecret:  "test-dispatch-secret",
 	}
 	return NewMetaWebhookHandler(cfg, enq, dedup, logger)
 }
@@ -162,6 +168,12 @@ func newTestHandler(t *testing.T) *MetaWebhookHandler {
 		PhoneNumberID:   "123",
 		SystemUserToken: "tok",
 		GraphAPIVersion: "v21.0",
+		// dispatchReady() exige chain completa pra wire callback nas mensagens
+		// enfileiradas. Sem isso o webhook devolve 503 (fail-loud em vez de
+		// silenciar respostas órfãs). Helpers expõem chain válida por default;
+		// tests específicos de "chain incompleta" sobrescrevem antes de chamar.
+		SelfCallbackURL: "https://test/callback",
+		DispatchSecret:  "test-dispatch-secret",
 	}
 	return NewMetaWebhookHandler(cfg, nil, nil, logger)
 }
@@ -839,6 +851,8 @@ func TestInbound_NfmReplyAppliesFlowRegistry(t *testing.T) {
 	cfg := &config.MetaConfig{
 		Enabled: true, VerifyToken: "t", AppSecret: "test-app-secret",
 		PhoneNumberID: "1", SystemUserToken: "tok", GraphAPIVersion: "v21.0",
+		SelfCallbackURL:    "https://test/callback",
+		DispatchSecret:     "test-dispatch-secret",
 		FlowRegistry:       "luminaria:reparo_luminaria;saude:agenda_saude",
 		FlowDefaultService: "default_service",
 	}

--- a/internal/handlers/meta_webhook_test.go
+++ b/internal/handlers/meta_webhook_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/prefeitura-rio/app-eai-agent-gateway/internal/config"
 	"github.com/prefeitura-rio/app-eai-agent-gateway/internal/models"
+	"github.com/prefeitura-rio/app-eai-agent-gateway/internal/services"
 )
 
 // ─── Mocks ───────────────────────────────────────────────────────────────
@@ -705,6 +706,81 @@ func TestInbound_InFlightClaimReturns503(t *testing.T) {
 	h.HandleInbound(c)
 	if w.Code != http.StatusServiceUnavailable {
 		t.Errorf("expected 503 (in-flight → retry), got %d", w.Code)
+	}
+}
+
+// raceDedup força SETNX false + Get retornando services.ErrKeyNotFound,
+// simulando race onde a chave foi evicted (Redis LRU pressure / TTL expiry)
+// entre o SETNX false e o Get subsequente. RedisService real retorna esse
+// erro nesse caso; o mockDedup vanilla retorna ("", nil) e ofusca o path.
+type raceDedup struct{ mockDedup }
+
+func (r *raceDedup) SetNX(_ context.Context, _ string, _ string, _ time.Duration) (bool, error) {
+	return false, nil
+}
+func (r *raceDedup) Get(_ context.Context, _ string) (string, error) {
+	return "", services.ErrKeyNotFound
+}
+
+func TestInbound_SetNXFalseGetNotFoundReturns503(t *testing.T) {
+	// Race: SETNX retorna false (chave existia no momento da chamada) mas
+	// Get retorna ErrKeyNotFound (Redis LRU evict entre as 2 chamadas).
+	// Handler trate como in-flight → 503 pra Meta retentar; sem isso o
+	// log antigo dizia "Get failed" semanticamente incorreto e mascarava
+	// o diagnóstico.
+	enq := &mockEnqueuer{}
+	dedup := &raceDedup{}
+	h := newTestHandlerWithDeps(t, enq, dedup)
+	payload := `{
+	  "object": "whatsapp_business_account",
+	  "entry": [{"id": "WABA_ID", "changes": [{"field": "messages",
+	    "value": {"messaging_product":"whatsapp",
+	      "metadata":{"display_phone_number":"21","phone_number_id":"1"},
+	      "messages":[{"from":"5500","id":"wamid.RACE","timestamp":"1","type":"text","text":{"body":"x"}}]
+	    }}]}]}`
+	body := []byte(payload)
+	sig := signBody(t, body, "test-app-secret")
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/meta/webhook", bytes.NewReader(body))
+	c.Request.Header.Set("X-Hub-Signature-256", sig)
+	h.HandleInbound(c)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected 503 (SETNX false + Get not-found → retry), got %d", w.Code)
+	}
+	if enq.callCount() != 0 {
+		t.Errorf("expected zero enqueues, got %d", enq.callCount())
+	}
+}
+
+func TestInbound_SelfLoopGuardAllowsThroughOnEmptyDisplayPhone(t *testing.T) {
+	// Sandbox edge case: Meta entrega webhook com display_phone_number vazio.
+	// Anti-loop guard não consegue comparar E.164; logamos Warn e seguimos
+	// (não rejeitamos a mensagem). Asserta path completo: msg passa pelo
+	// guard sem block e chega no enqueue.
+	enq := &mockEnqueuer{}
+	dedup := newMockDedup()
+	h := newTestHandlerWithDeps(t, enq, dedup)
+	// from == display_phone_number normalizaria mas display vazio.
+	payload := `{
+	  "object": "whatsapp_business_account",
+	  "entry": [{"id": "WABA_ID", "changes": [{"field": "messages",
+	    "value": {"messaging_product":"whatsapp",
+	      "metadata":{"display_phone_number":"","phone_number_id":"1"},
+	      "messages":[{"from":"5521989091014","id":"wamid.NODISP","timestamp":"1","type":"text","text":{"body":"hello"}}]
+	    }}]}]}`
+	body := []byte(payload)
+	sig := signBody(t, body, "test-app-secret")
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/meta/webhook", bytes.NewReader(body))
+	c.Request.Header.Set("X-Hub-Signature-256", sig)
+	h.HandleInbound(c)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 (guard degraded but msg flows), got %d body=%s", w.Code, w.Body.String())
+	}
+	if enq.callCount() != 1 {
+		t.Errorf("expected 1 enqueue (guard didn't block), got %d", enq.callCount())
 	}
 }
 

--- a/internal/handlers/meta_webhook_test.go
+++ b/internal/handlers/meta_webhook_test.go
@@ -1065,3 +1065,91 @@ func TestValidateSignature_EmptySecretFailsClosed(t *testing.T) {
 	}
 }
 
+// ────────────────────────────────────────────────────────────
+// dispatchReady — placeholder handling
+// ────────────────────────────────────────────────────────────
+
+func TestDispatchReady_RejectsPlaceholderInAnyField(t *testing.T) {
+	// Operador pode esquecer de hidratar um secret no Infisical. Sem o
+	// placeholder gate em TODOS os 4 campos, dispatchReady() retornaria true
+	// e o webhook tentaria autenticar Meta Graph com Bearer token literal
+	// "REPLACE_VIA_RUNTIME_MANAGER_PROPERTIES" — falha runtime opaca, não
+	// gate de startup.
+	const placeholder = "REPLACE_VIA_RUNTIME_MANAGER_PROPERTIES"
+	base := &config.MetaConfig{
+		Enabled:         true,
+		VerifyToken:     "vt",
+		AppSecret:       "secret",
+		SelfCallbackURL: "https://gateway/dispatch",
+		DispatchSecret:  "ds",
+		SystemUserToken: "tok",
+		PhoneNumberID:   "pid",
+		GraphAPIVersion: "v21.0",
+	}
+	gin.SetMode(gin.TestMode)
+	logger := logrus.New()
+	logger.SetOutput(stdio.Discard)
+
+	// Sanity: base é completo, dispatchReady true.
+	hOK := NewMetaWebhookHandler(base, nil, nil, logger)
+	if !hOK.dispatchReady() {
+		t.Fatal("base config should be dispatchReady; check helper")
+	}
+
+	cases := []struct {
+		field string
+		mut   func(*config.MetaConfig)
+	}{
+		{"SelfCallbackURL", func(c *config.MetaConfig) { c.SelfCallbackURL = placeholder }},
+		{"DispatchSecret", func(c *config.MetaConfig) { c.DispatchSecret = placeholder }},
+		{"SystemUserToken", func(c *config.MetaConfig) { c.SystemUserToken = placeholder }},
+		{"PhoneNumberID", func(c *config.MetaConfig) { c.PhoneNumberID = placeholder }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.field, func(t *testing.T) {
+			cfg := *base // copy
+			tc.mut(&cfg)
+			h := NewMetaWebhookHandler(&cfg, nil, nil, logger)
+			if h.dispatchReady() {
+				t.Errorf("dispatchReady() should return false when %s is placeholder", tc.field)
+			}
+		})
+	}
+}
+
+func TestDispatchReady_RejectsEmptyInAnyField(t *testing.T) {
+	base := &config.MetaConfig{
+		Enabled:         true,
+		VerifyToken:     "vt",
+		AppSecret:       "secret",
+		SelfCallbackURL: "https://gateway/dispatch",
+		DispatchSecret:  "ds",
+		SystemUserToken: "tok",
+		PhoneNumberID:   "pid",
+		GraphAPIVersion: "v21.0",
+	}
+	gin.SetMode(gin.TestMode)
+	logger := logrus.New()
+	logger.SetOutput(stdio.Discard)
+
+	cases := []struct {
+		field string
+		mut   func(*config.MetaConfig)
+	}{
+		{"SelfCallbackURL", func(c *config.MetaConfig) { c.SelfCallbackURL = "" }},
+		{"DispatchSecret", func(c *config.MetaConfig) { c.DispatchSecret = "" }},
+		{"SystemUserToken", func(c *config.MetaConfig) { c.SystemUserToken = "" }},
+		{"PhoneNumberID", func(c *config.MetaConfig) { c.PhoneNumberID = "" }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.field, func(t *testing.T) {
+			cfg := *base
+			tc.mut(&cfg)
+			h := NewMetaWebhookHandler(&cfg, nil, nil, logger)
+			if h.dispatchReady() {
+				t.Errorf("dispatchReady() should return false when %s is empty", tc.field)
+			}
+		})
+	}
+}
+

--- a/internal/handlers/meta_webhook_test.go
+++ b/internal/handlers/meta_webhook_test.go
@@ -801,6 +801,117 @@ func TestInbound_DedupSetNXErrorContinuesWithoutBlock(t *testing.T) {
 	}
 }
 
+func TestInbound_AntiLoopGuardDropsSelfMessages(t *testing.T) {
+	// Mensagem em que `from` bate com `display_phone_number` da WABA = bot
+	// se respondendo a si mesmo. Drop pra evitar cascade infinita.
+	enq := &mockEnqueuer{}
+	h := newTestHandlerWithDeps(t, enq, newMockDedup())
+	payload := `{
+	  "object": "whatsapp_business_account",
+	  "entry": [{"id": "WABA_ID", "changes": [{"field": "messages",
+	    "value": {"messaging_product":"whatsapp",
+	      "metadata":{"display_phone_number":"5521989091014","phone_number_id":"1"},
+	      "messages":[{"from":"5521989091014","id":"wamid.LOOP","timestamp":"1","type":"text","text":{"body":"loop"}}]
+	    }}]}]}`
+	body := []byte(payload)
+	sig := signBody(t, body, "test-app-secret")
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/meta/webhook", bytes.NewReader(body))
+	c.Request.Header.Set("X-Hub-Signature-256", sig)
+	h.HandleInbound(c)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 (dropped self-loop), got %d", w.Code)
+	}
+	if enq.callCount() != 0 {
+		t.Errorf("expected zero enqueues (self-loop drop), got %d", enq.callCount())
+	}
+}
+
+func TestInbound_NfmReplyAppliesFlowRegistry(t *testing.T) {
+	// Submissão de Flow "Luminária" deve adicionar service_name pra Engine
+	// rotear pelo MCP correto.
+	enq := &mockEnqueuer{}
+	dedup := newMockDedup()
+	gin.SetMode(gin.TestMode)
+	logger := logrus.New()
+	logger.SetOutput(stdio.Discard)
+	cfg := &config.MetaConfig{
+		Enabled: true, VerifyToken: "t", AppSecret: "test-app-secret",
+		PhoneNumberID: "1", SystemUserToken: "tok", GraphAPIVersion: "v21.0",
+		FlowRegistry:       "luminaria:reparo_luminaria;saude:agenda_saude",
+		FlowDefaultService: "default_service",
+	}
+	h := NewMetaWebhookHandler(cfg, enq, dedup, logger)
+
+	payload := `{
+	  "object": "whatsapp_business_account",
+	  "entry": [{"id": "WABA_ID", "changes": [{"field": "messages",
+	    "value": {"messaging_product":"whatsapp",
+	      "metadata":{"display_phone_number":"21","phone_number_id":"1"},
+	      "messages":[{"from":"5500","id":"wamid.FLOW","timestamp":"1","type":"interactive",
+	        "interactive":{
+	          "type":"nfm_reply",
+	          "nfm_reply":{
+	            "name":"Luminária Quebrada",
+	            "response_json":"{\"endereco\":\"Rua X, 100\",\"defeito\":\"piscando\"}"
+	          }
+	        }}]
+	    }}]}]}`
+	body := []byte(payload)
+	sig := signBody(t, body, "test-app-secret")
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/meta/webhook", bytes.NewReader(body))
+	c.Request.Header.Set("X-Hub-Signature-256", sig)
+	h.HandleInbound(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	req := enq.lastCall()
+	if req == nil {
+		t.Fatal("expected enqueue call")
+	}
+	if req.Metadata["service_name"] != "reparo_luminaria" {
+		t.Errorf("expected service_name=reparo_luminaria, got %v", req.Metadata["service_name"])
+	}
+	form, ok := req.Metadata["form_submission"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected form_submission map, got %T", req.Metadata["form_submission"])
+	}
+	if form["endereco"] != "Rua X, 100" {
+		t.Errorf("expected form_submission.endereco=Rua X, 100, got %v", form["endereco"])
+	}
+}
+
+func TestInbound_StatusCallbackPersistsToDedup(t *testing.T) {
+	// Status callbacks devem ser persistidos no Redis (key meta:status:<wamid>)
+	// pra Engine/operadores consultarem delivery state.
+	dedup := newMockDedup()
+	h := newTestHandlerWithDeps(t, &mockEnqueuer{}, dedup)
+	payload := `{
+	  "object": "whatsapp_business_account",
+	  "entry": [{"id": "WABA_ID", "changes": [{"field": "messages",
+	    "value": {"messaging_product":"whatsapp",
+	      "metadata":{"display_phone_number":"21","phone_number_id":"1"},
+	      "statuses":[{"id":"wamid.SENT","status":"delivered","timestamp":"1","recipient_id":"5500"}]
+	    }}]}]}`
+	body := []byte(payload)
+	sig := signBody(t, body, "test-app-secret")
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/meta/webhook", bytes.NewReader(body))
+	c.Request.Header.Set("X-Hub-Signature-256", sig)
+	h.HandleInbound(c)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+	if !dedup.has("meta:status:wamid.SENT") {
+		t.Error("expected status callback persisted to dedup store")
+	}
+}
+
 func TestInbound_NoMessageHandlerReturns503(t *testing.T) {
 	// Sem MessageEnqueuer wired, text também cai em routeFailed → 503.
 	gin.SetMode(gin.TestMode)

--- a/internal/handlers/workers/message_handlers.go
+++ b/internal/handlers/workers/message_handlers.go
@@ -175,7 +175,7 @@ func CreateUserMessageHandler(deps *MessageHandlerDependencies) func(context.Con
 			// que sucede silenciosamente sobrescreveria a semântica — o branch
 			// `else if lockStoreErr != nil` (linha ~258) classifica erro de
 			// infra distintamente de contention. Não remover o break sem
-            // reavaliar essa lógica.
+			// reavaliar essa lógica.
 			var lockStoreErr error
 			lockCtx, lockCancel := context.WithTimeout(ctx, lockTotalTimeout)
 			for attempt := 0; attempt < lockMaxAttempts; attempt++ {

--- a/internal/handlers/workers/message_handlers.go
+++ b/internal/handlers/workers/message_handlers.go
@@ -202,10 +202,17 @@ func CreateUserMessageHandler(deps *MessageHandlerDependencies) func(context.Con
 							return
 						case <-ticker.C:
 							renewCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-							// Renewal via SetNX falha (key exists) — usar Set
-							// direto pra atualizar TTL (mantém o holder igual).
-							_ = deps.RedisService.Set(renewCtx, lockKey, lockHolder, lockTTL)
+							// CAS Lua: só renova se ainda somos o titular.
+							// Sem isso, Set unconditional roubaria lock de
+							// outro worker se TTL expirou mid-process.
+							ok, renewErr := deps.RedisService.RenewLock(renewCtx, lockKey, lockHolder, lockTTL)
 							cancel()
+							if renewErr != nil {
+								logger.WithError(renewErr).Debug("phone-lock renewal error (continuing)")
+							} else if !ok {
+								logger.Warn("phone-lock lost during processing (TTL expired or stolen)")
+								return // parar renovação — não somos mais donos
+							}
 						}
 					}
 				}()

--- a/internal/handlers/workers/message_handlers.go
+++ b/internal/handlers/workers/message_handlers.go
@@ -168,6 +168,14 @@ func CreateUserMessageHandler(deps *MessageHandlerDependencies) func(context.Con
 			// Discrimina infra-failure de contention pura — só contention sem
 			// erro vira transient requeue; infra-failure proceeds degraded
 			// (sem lock) pra evitar hot-loop de requeue indefinido.
+			//
+			// INVARIANTE LOAD-BEARING: o `break` na branch lockErr != nil é
+			// crítico. lockStoreErr é setado APENAS uma vez; se removermos o
+			// break (e.g. pra "tentar de novo após erro"), um attempt posterior
+			// que sucede silenciosamente sobrescreveria a semântica — o branch
+			// `else if lockStoreErr != nil` (linha ~258) classifica erro de
+			// infra distintamente de contention. Não remover o break sem
+            // reavaliar essa lógica.
 			var lockStoreErr error
 			lockCtx, lockCancel := context.WithTimeout(ctx, lockTotalTimeout)
 			for attempt := 0; attempt < lockMaxAttempts; attempt++ {
@@ -175,7 +183,7 @@ func CreateUserMessageHandler(deps *MessageHandlerDependencies) func(context.Con
 				if lockErr != nil {
 					lockStoreErr = lockErr
 					logger.WithError(lockErr).Warn("phone-lock acquire error (degraded); proceeding without lock")
-					break
+					break // INVARIANTE — ver bloco acima.
 				}
 				if ok {
 					lockAcquired = true
@@ -458,8 +466,6 @@ func processUserMessage(ctx context.Context, msg *models.QueueMessage, deps *Mes
 		"has_previous_message": msg.PreviousMessage != nil,
 		"provider":             msg.Provider,
 	}).Info("Processing user message")
-
-	logger.Info("DEBUG: Starting processUserMessage function execution")
 
 	// Validate provider - currently only support google_agent_engine
 	if msg.Provider != "google_agent_engine" {

--- a/internal/handlers/workers/message_handlers.go
+++ b/internal/handlers/workers/message_handlers.go
@@ -217,12 +217,19 @@ func CreateUserMessageHandler(deps *MessageHandlerDependencies) func(context.Con
 							cancel()
 							if renewErr != nil {
 								failures++
-								logger.WithError(renewErr).WithField("consecutive_failures", failures).Warn("phone-lock renewal error")
-								if failures >= maxConsecutiveFailures {
-									logger.WithField("consecutive_failures", failures).Error("phone-lock renewal failed repeatedly — Redis outage suspected; lock effectively lost")
-									return
+								// Severidade graduada: 1ª/2ª falhas são quase certo
+								// blip transitório (Redis reconnect, mTLS handshake);
+								// Debug evita spam de alerta em CloudHub. 3ª já é
+								// outage prolongada (~3× renewInterval = ~30min com
+								// lockTTL=30min) — promover pra Error + return.
+								if failures < maxConsecutiveFailures {
+									logger.WithError(renewErr).WithField("consecutive_failures", failures).
+										Debug("phone-lock renewal transient error (retrying)")
+									continue
 								}
-								continue
+								logger.WithError(renewErr).WithField("consecutive_failures", failures).
+									Error("phone-lock renewal failed repeatedly — Redis outage suspected; lock effectively lost")
+								return
 							}
 							failures = 0 // reset após sucesso
 							if !ok {

--- a/internal/handlers/workers/message_handlers.go
+++ b/internal/handlers/workers/message_handlers.go
@@ -141,6 +141,91 @@ func CreateUserMessageHandler(deps *MessageHandlerDependencies) func(context.Con
 			logger.WithError(err).Error("Failed to update task status to processing")
 		}
 
+		// Per-phone lock pra serializar processamento por cidadão. Múltiplos
+		// workers (MAX_PARALLEL=8) consomem a mesma queue, então duas mensagens
+		// do mesmo user_number podem ser processadas concorrentes — risco de
+		// reordering visível ao cidadão.
+		//
+		// TTL alinhado com RabbitMQ.MessageTimeout (worker run máximo). Se
+		// MessageTimeout não setado, defaulta 30min. Goroutine de renewal
+		// estende o TTL a cada TTL/3 enquanto processamento estiver vivo,
+		// evitando que lock expire mid-Engine-call e outra mensagem do mesmo
+		// user_number entre concorrentemente.
+		if queueMsg.UserNumber != "" {
+			lockKey := "worker:phone-lock:" + queueMsg.UserNumber
+			lockHolder := queueMsg.ID
+			lockTTL := deps.Config.RabbitMQ.MessageTimeout
+			if lockTTL < 5*time.Minute {
+				lockTTL = 30 * time.Minute
+			}
+			const (
+				lockMaxAttempts  = 50
+				lockBackoff      = 100 * time.Millisecond
+				lockTotalTimeout = 10 * time.Second
+			)
+			lockAcquired := false
+			lockCtx, lockCancel := context.WithTimeout(ctx, lockTotalTimeout)
+			for attempt := 0; attempt < lockMaxAttempts; attempt++ {
+				ok, lockErr := deps.RedisService.AcquireLock(lockCtx, lockKey, lockHolder, lockTTL)
+				if lockErr != nil {
+					logger.WithError(lockErr).Warn("phone-lock acquire error (degraded); proceeding without lock")
+					break
+				}
+				if ok {
+					lockAcquired = true
+					break
+				}
+				select {
+				case <-lockCtx.Done():
+					attempt = lockMaxAttempts
+				case <-time.After(lockBackoff):
+				}
+			}
+			lockCancel()
+			if lockAcquired {
+				// Renewal goroutine: SETEX a cada TTL/3 enquanto processamento
+				// está vivo. Stops quando defer fecha doneCh ou ReleaseLock
+				// finaliza. Sem isso, Engine call demorada (>TTL) faz outro
+				// worker pegar lock expirado e processar concorrente — quebra
+				// a serialização que o lock prometia.
+				renewInterval := lockTTL / 3
+				if renewInterval < 30*time.Second {
+					renewInterval = 30 * time.Second
+				}
+				doneCh := make(chan struct{})
+				go func() {
+					ticker := time.NewTicker(renewInterval)
+					defer ticker.Stop()
+					for {
+						select {
+						case <-doneCh:
+							return
+						case <-ticker.C:
+							renewCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+							// Renewal via SetNX falha (key exists) — usar Set
+							// direto pra atualizar TTL (mantém o holder igual).
+							_ = deps.RedisService.Set(renewCtx, lockKey, lockHolder, lockTTL)
+							cancel()
+						}
+					}
+				}()
+				defer func() {
+					close(doneCh)
+					relCtx, relCancel := context.WithTimeout(context.Background(), 2*time.Second)
+					defer relCancel()
+					if relErr := deps.RedisService.ReleaseLock(relCtx, lockKey, lockHolder); relErr != nil {
+						logger.WithError(relErr).Debug("phone-lock release (likely TTL expired, ok)")
+					}
+				}()
+			} else if queueMsg.UserNumber != "" {
+				logger.WithFields(logrus.Fields{
+					"user_number": queueMsg.UserNumber,
+					"message_id":  queueMsg.ID,
+				}).Warn("phone-lock not acquired in time; requeueing message")
+				return fmt.Errorf("phone-lock contention for %s; requeue", queueMsg.UserNumber)
+			}
+		}
+
 		// Process the user message with optional OTel tracing
 		var response string
 		var err error

--- a/internal/handlers/workers/message_handlers.go
+++ b/internal/handlers/workers/message_handlers.go
@@ -164,10 +164,16 @@ func CreateUserMessageHandler(deps *MessageHandlerDependencies) func(context.Con
 				lockTotalTimeout = 10 * time.Second
 			)
 			lockAcquired := false
+			// lockStoreErr captura erro de infra (Redis down, ctx cancelado).
+			// Discrimina infra-failure de contention pura — só contention sem
+			// erro vira transient requeue; infra-failure proceeds degraded
+			// (sem lock) pra evitar hot-loop de requeue indefinido.
+			var lockStoreErr error
 			lockCtx, lockCancel := context.WithTimeout(ctx, lockTotalTimeout)
 			for attempt := 0; attempt < lockMaxAttempts; attempt++ {
 				ok, lockErr := deps.RedisService.AcquireLock(lockCtx, lockKey, lockHolder, lockTTL)
 				if lockErr != nil {
+					lockStoreErr = lockErr
 					logger.WithError(lockErr).Warn("phone-lock acquire error (degraded); proceeding without lock")
 					break
 				}
@@ -234,16 +240,28 @@ func CreateUserMessageHandler(deps *MessageHandlerDependencies) func(context.Con
 						logger.WithError(relErr).Debug("phone-lock release (likely TTL expired, ok)")
 					}
 				}()
+			} else if lockStoreErr != nil {
+				// Redis indisponível: o resto do pipeline (SetTaskResult,
+				// GetCallbackURL) também depende de Redis e só loga erro
+				// sem propagar. Prosseguir aqui ACKaria a mensagem com
+				// resposta perdida. Retornar erro normal pro consumer fazer
+				// retry/DLQ accounting padrão.
+				logger.WithError(lockStoreErr).WithField("message_id", queueMsg.ID).
+					Error("phone-lock acquire failed (Redis outage); returning error for normal retry/DLQ accounting")
+				return fmt.Errorf("phone-lock acquire failed: %w", lockStoreErr)
 			} else if queueMsg.UserNumber != "" {
 				logger.WithFields(logrus.Fields{
 					"user_number": queueMsg.UserNumber,
 					"message_id":  queueMsg.ID,
-				}).Warn("phone-lock not acquired in time; backing off before requeue")
-				// Backoff antes do return pra evitar tight loop entre 2 workers
-				// disputando o mesmo phone-lock — sem isso, NACK+requeue imediato
-				// vira hot loop até timeout/DLQ. 2s alinhado ao lockTimeout típico.
-				time.Sleep(2 * time.Second)
-				return fmt.Errorf("phone-lock contention for %s; requeue", queueMsg.UserNumber)
+				}).Info("phone-lock not acquired in time; transient requeue (lock held by sibling worker)")
+				// Contention pura (sem erro de infra) é fluxo normal — outro
+				// worker tem o lock do mesmo cidadão. Retornar erro genérico
+				// aqui faria o consumer queimar retry budget e, com
+				// RABBITMQ_MAX_RETRIES=-1 (default), mandaria rajadas do mesmo
+				// número direto pra DLQ na primeira tentativa. Sinaliza
+				// transient requeue: consumer republica preservando retryCount,
+				// com backoff explícito (não tight loop).
+				return lockContentionRequeue{userNumber: queueMsg.UserNumber}
 			}
 		}
 

--- a/internal/handlers/workers/message_handlers.go
+++ b/internal/handlers/workers/message_handlers.go
@@ -196,6 +196,8 @@ func CreateUserMessageHandler(deps *MessageHandlerDependencies) func(context.Con
 				go func() {
 					ticker := time.NewTicker(renewInterval)
 					defer ticker.Stop()
+					const maxConsecutiveFailures = 3
+					failures := 0
 					for {
 						select {
 						case <-doneCh:
@@ -208,8 +210,16 @@ func CreateUserMessageHandler(deps *MessageHandlerDependencies) func(context.Con
 							ok, renewErr := deps.RedisService.RenewLock(renewCtx, lockKey, lockHolder, lockTTL)
 							cancel()
 							if renewErr != nil {
-								logger.WithError(renewErr).Debug("phone-lock renewal error (continuing)")
-							} else if !ok {
+								failures++
+								logger.WithError(renewErr).WithField("consecutive_failures", failures).Warn("phone-lock renewal error")
+								if failures >= maxConsecutiveFailures {
+									logger.WithField("consecutive_failures", failures).Error("phone-lock renewal failed repeatedly — Redis outage suspected; lock effectively lost")
+									return
+								}
+								continue
+							}
+							failures = 0 // reset após sucesso
+							if !ok {
 								logger.Warn("phone-lock lost during processing (TTL expired or stolen)")
 								return // parar renovação — não somos mais donos
 							}
@@ -228,7 +238,11 @@ func CreateUserMessageHandler(deps *MessageHandlerDependencies) func(context.Con
 				logger.WithFields(logrus.Fields{
 					"user_number": queueMsg.UserNumber,
 					"message_id":  queueMsg.ID,
-				}).Warn("phone-lock not acquired in time; requeueing message")
+				}).Warn("phone-lock not acquired in time; backing off before requeue")
+				// Backoff antes do return pra evitar tight loop entre 2 workers
+				// disputando o mesmo phone-lock — sem isso, NACK+requeue imediato
+				// vira hot loop até timeout/DLQ. 2s alinhado ao lockTimeout típico.
+				time.Sleep(2 * time.Second)
 				return fmt.Errorf("phone-lock contention for %s; requeue", queueMsg.UserNumber)
 			}
 		}

--- a/internal/handlers/workers/transient_requeue.go
+++ b/internal/handlers/workers/transient_requeue.go
@@ -1,0 +1,27 @@
+package workers
+
+import (
+	"fmt"
+	"time"
+)
+
+// lockContentionRequeue implementa services.TransientRequeueError.
+// Retornado quando o worker não conseguiu adquirir o phone-lock antes
+// do timeout (lockTotalTimeout). Sinaliza ao consumer pra republicar
+// na fila sem queimar retry budget — contention é serialização per-user
+// esperada, não falha de processamento.
+type lockContentionRequeue struct {
+	userNumber string
+}
+
+func (e lockContentionRequeue) Error() string {
+	return fmt.Sprintf("phone-lock contention for %s; transient requeue", e.userNumber)
+}
+
+// TransientRequeueDelay — 2s é curto o suficiente pra repor a mensagem
+// pouco depois do lock holder esperado terminar, mas longo o suficiente
+// pra evitar tight loop quando dois workers entram em lockstep. Bate com
+// lockTotalTimeout (10s) — máx ~5 requeues por minuto por mensagem.
+func (e lockContentionRequeue) TransientRequeueDelay() time.Duration {
+	return 2 * time.Second
+}

--- a/internal/models/meta_webhook.go
+++ b/internal/models/meta_webhook.go
@@ -1,0 +1,145 @@
+// Package models — Meta WhatsApp Business Cloud webhook payload shapes.
+//
+// Inspirado na documentação oficial Meta:
+// https://developers.facebook.com/docs/whatsapp/cloud-api/webhooks/components
+//
+// Escopo do POC: text inbound + status callbacks + envelope. Tipos avançados
+// (image/audio/video/location/interactive) vão ser adicionados em fases
+// posteriores conforme migration plan do ADR (cortar Mule).
+//
+// Todos os campos `omitempty` porque Meta envia payloads heterogêneos — uma
+// entrada pode ter apenas `messages`, outra apenas `statuses`. Parsing
+// tolerante.
+package models
+
+// MetaWebhookEnvelope — shape externo do webhook (object + entry array).
+type MetaWebhookEnvelope struct {
+	Object string      `json:"object"`
+	Entry  []MetaEntry `json:"entry"`
+}
+
+// MetaEntry — uma entrada do envelope, normalmente uma WABA + changes.
+type MetaEntry struct {
+	ID      string       `json:"id"`
+	Changes []MetaChange `json:"changes"`
+}
+
+// MetaChange — single change pra um field específico (e.g. "messages").
+type MetaChange struct {
+	Field string          `json:"field"`
+	Value MetaChangeValue `json:"value"`
+}
+
+// MetaChangeValue — payload real. Pode conter messages, statuses, contacts,
+// errors. POC consome só messages + statuses.
+type MetaChangeValue struct {
+	MessagingProduct string          `json:"messaging_product"`
+	Metadata         MetaMetadata    `json:"metadata"`
+	Contacts         []MetaContact   `json:"contacts,omitempty"`
+	Messages         []MetaMessage   `json:"messages,omitempty"`
+	Statuses         []MetaStatus    `json:"statuses,omitempty"`
+	Errors           []MetaErrorItem `json:"errors,omitempty"`
+}
+
+// MetaMetadata — sobre o WABA receptor.
+type MetaMetadata struct {
+	DisplayPhoneNumber string `json:"display_phone_number"`
+	PhoneNumberID      string `json:"phone_number_id"`
+}
+
+// MetaContact — info do cidadão remetente.
+type MetaContact struct {
+	WaID    string          `json:"wa_id"`
+	Profile MetaContactName `json:"profile"`
+}
+
+// MetaContactName — nome opcional do contato.
+type MetaContactName struct {
+	Name string `json:"name"`
+}
+
+// MetaMessage — mensagem inbound. Type discrimina shape (text, image, etc).
+type MetaMessage struct {
+	From      string           `json:"from"`
+	ID        string           `json:"id"`
+	Timestamp string           `json:"timestamp"`
+	Type      string           `json:"type"`
+	Text      *MetaText        `json:"text,omitempty"`
+	Image     *MetaMedia       `json:"image,omitempty"`
+	Audio     *MetaMedia       `json:"audio,omitempty"`
+	Video     *MetaMedia       `json:"video,omitempty"`
+	Document  *MetaMedia       `json:"document,omitempty"`
+	Sticker   *MetaMedia       `json:"sticker,omitempty"`
+	Location  *MetaLocation    `json:"location,omitempty"`
+	// Interactive cobre button_reply, list_reply, nfm_reply (Flow submission).
+	Interactive *MetaInteractive `json:"interactive,omitempty"`
+	Reaction    *MetaReaction    `json:"reaction,omitempty"`
+}
+
+// MetaText — body do texto inbound.
+type MetaText struct {
+	Body string `json:"body"`
+}
+
+// MetaMedia — referência a binário hosted na Meta CDN.
+// Bot precisa fazer GET /{media_id} pra obter URL temporária + GET nessa URL
+// pra baixar o conteúdo. Mule fazia isso; Gateway terá que replicar quando
+// suportar media inbound.
+type MetaMedia struct {
+	ID       string `json:"id"`
+	MimeType string `json:"mime_type,omitempty"`
+	SHA256   string `json:"sha256,omitempty"`
+	Filename string `json:"filename,omitempty"` // só pra document/sticker às vezes
+	Caption  string `json:"caption,omitempty"`  // image/video/document
+}
+
+// MetaLocation — coordenadas compartilhadas via "anexo → localização".
+type MetaLocation struct {
+	Latitude  float64 `json:"latitude"`
+	Longitude float64 `json:"longitude"`
+	Name      string  `json:"name,omitempty"`
+	Address   string  `json:"address,omitempty"`
+}
+
+// MetaInteractive — Flow/button/list reply.
+type MetaInteractive struct {
+	Type        string             `json:"type"`
+	ButtonReply *MetaInteractiveID `json:"button_reply,omitempty"`
+	ListReply   *MetaInteractiveID `json:"list_reply,omitempty"`
+	NFMReply    *MetaNFMReply      `json:"nfm_reply,omitempty"`
+}
+
+// MetaInteractiveID — comum a button_reply/list_reply.
+type MetaInteractiveID struct {
+	ID    string `json:"id"`
+	Title string `json:"title"`
+}
+
+// MetaNFMReply — WhatsApp Flow completion.
+type MetaNFMReply struct {
+	ResponseJSON string `json:"response_json"`
+	Body         string `json:"body,omitempty"`
+	Name         string `json:"name"`
+	FlowToken    string `json:"flow_token,omitempty"`
+}
+
+// MetaReaction — emoji em mensagem prévia.
+type MetaReaction struct {
+	MessageID string `json:"message_id"`
+	Emoji     string `json:"emoji"`
+}
+
+// MetaStatus — callback de status (sent/delivered/read/failed).
+type MetaStatus struct {
+	ID          string `json:"id"`
+	Status      string `json:"status"`
+	Timestamp   string `json:"timestamp"`
+	RecipientID string `json:"recipient_id"`
+}
+
+// MetaErrorItem — erro propagado pelo Meta (ex: outbound message failed).
+type MetaErrorItem struct {
+	Code    int    `json:"code"`
+	Title   string `json:"title"`
+	Message string `json:"message,omitempty"`
+}

--- a/internal/models/meta_webhook.go
+++ b/internal/models/meta_webhook.go
@@ -91,6 +91,11 @@ type MetaMedia struct {
 	SHA256   string `json:"sha256,omitempty"`
 	Filename string `json:"filename,omitempty"` // só pra document/sticker às vezes
 	Caption  string `json:"caption,omitempty"`  // image/video/document
+	// Voice é populado apenas em audio messages — true significa que o
+	// cidadão gravou voice note (push-to-talk no WhatsApp), false/ausente
+	// significa que mandou um audio file. Engine pode usar pra optar entre
+	// transcrição direta (voice) ou path mais elaborado.
+	Voice bool `json:"voice,omitempty"`
 }
 
 // MetaLocation — coordenadas compartilhadas via "anexo → localização".
@@ -110,9 +115,12 @@ type MetaInteractive struct {
 }
 
 // MetaInteractiveID — comum a button_reply/list_reply.
+// `Description` é populado apenas em list_reply (cada item da lista pode
+// ter description opcional); button_reply ignora.
 type MetaInteractiveID struct {
-	ID    string `json:"id"`
-	Title string `json:"title"`
+	ID          string `json:"id"`
+	Title       string `json:"title"`
+	Description string `json:"description,omitempty"`
 }
 
 // MetaNFMReply — WhatsApp Flow completion.

--- a/internal/services/callback_service.go
+++ b/internal/services/callback_service.go
@@ -196,6 +196,17 @@ func (s *CallbackService) sendCallbackRequest(ctx context.Context, callbackURL s
 		req.Header.Set("X-Signature-SHA256", signature)
 	}
 
+	// Meta-direct dispatch secret: o callback do worker pra /meta/dispatch
+	// requer este header. Restrito ao SelfCallbackURL configurado — enviar
+	// o secret pra callbacks user-provided permitiria o receiver logar e
+	// reutilizar pra dispararem outbound Meta arbitrário. Match exato pra
+	// evitar prefix-collision em URLs com path adicional.
+	if s.config.Meta.DispatchSecret != "" &&
+		s.config.Meta.SelfCallbackURL != "" &&
+		callbackURL == s.config.Meta.SelfCallbackURL {
+		req.Header.Set("X-Meta-Dispatch-Secret", s.config.Meta.DispatchSecret)
+	}
+
 	// Send request
 	resp, err := s.httpClient.Do(req)
 	if err != nil {

--- a/internal/services/callback_service.go
+++ b/internal/services/callback_service.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -72,14 +73,28 @@ func (s *CallbackService) ValidateCallbackURL(callbackURL string) error {
 		return fmt.Errorf("callback URL must use HTTP or HTTPS protocol")
 	}
 
-	// Check for localhost and private IP addresses
+	// Check for localhost (string-form). IP-form loopback ("127.0.0.1", "::1",
+	// "::ffff:127.0.0.1", "::ffff:7f00:1") é coberto pelo `IsLoopback()` no
+	// bloco abaixo — string-equality cobre só o caso "localhost" (DNS).
 	host := parsedURL.Hostname()
-	if host == "localhost" || host == "127.0.0.1" || host == "::1" {
+	if strings.EqualFold(host, "localhost") {
 		return fmt.Errorf("callback URL cannot use localhost")
 	}
 
-	// Check if host is an IP address and if it's private
-	if ip := net.ParseIP(host); ip != nil {
+	// Strip IPv6 zone index ("fe80::1%eth0" → "fe80::1") antes do parse.
+	// net.ParseIP retorna nil em string com zone; bypass via
+	// `http://[::1%25lo0]/` (Go resolve pra ::1 via zone) sem o strip.
+	ipStr := host
+	if i := strings.IndexByte(host, '%'); i >= 0 {
+		ipStr = host[:i]
+	}
+	// Check if host is an IP address. Tratamento robusto a IPv4-mapped IPv6
+	// (`::ffff:127.0.0.1`, `::ffff:10.0.0.1`) — sem isso, atacante poderia
+	// bypass via IPv4-mapped IPv6. IsLoopback/IsUnspecified normalizam.
+	if ip := net.ParseIP(ipStr); ip != nil {
+		if ip.IsLoopback() || ip.IsUnspecified() || ip.IsLinkLocalUnicast() {
+			return fmt.Errorf("callback URL cannot use loopback, unspecified, or link-local IP")
+		}
 		if isPrivateIP(ip) {
 			return fmt.Errorf("callback URL cannot use private IP addresses")
 		}
@@ -268,8 +283,17 @@ func isRetriableError(err error) bool {
 	return true
 }
 
-// isPrivateIP checks if an IP address is in a private range
+// isPrivateIP checks if an IP address is in a private range.
+//
+// Normaliza IPv4-mapped IPv6 (`::ffff:a.b.c.d`) antes do match — sem isso,
+// atacante poderia bypass via `http://[::ffff:10.0.0.1]/...` (Go transport
+// resolve pro IPv4 atrás, mas o CIDR match em `10.0.0.0/8` falha porque
+// `network.Contains(::ffff:10.0.0.1)` retorna false). Stdlib `net.IP.To4()`
+// devolve o IPv4 puro se disponível; caso contrário mantém o IPv6 original.
 func isPrivateIP(ip net.IP) bool {
+	if v4 := ip.To4(); v4 != nil {
+		ip = v4
+	}
 	privateRanges := []string{
 		"10.0.0.0/8",
 		"172.16.0.0/12",

--- a/internal/services/message_consumer.go
+++ b/internal/services/message_consumer.go
@@ -320,7 +320,14 @@ func (c *Consumer) handleRequeueShutdown(msg amqp.Delivery, kind, signal string,
 	logger.WithFields(logrus.Fields{"kind": kind, "signal": signal}).
 		Info("Requeue backoff interrupted by shutdown; nack+requeue")
 	if nackErr := msg.Nack(false, true); nackErr != nil {
-		logger.WithError(nackErr).Error("Failed to NACK during shutdown")
+		// Mesma análise do delivery_stuck no requeueWithDelay: NACK falhando
+		// durante shutdown deixa a delivery presa até reconnect. Log Error
+		// + event canônico pra alerting.
+		logger.WithError(nackErr).WithFields(logrus.Fields{
+			"event":  "delivery_stuck_pending_redelivery",
+			"kind":   kind,
+			"signal": signal,
+		}).Error("Failed to NACK during shutdown — delivery unacked")
 	}
 }
 
@@ -359,7 +366,15 @@ func (c *Consumer) requeueWithDelay(
 		logger.WithError(pubErr).WithField("kind", kind).
 			Error("publishRetryMessage failed; nack+requeue pra evitar loss")
 		if nackErr := msg.Nack(false, true); nackErr != nil {
-			logger.WithError(nackErr).Error("Failed to NACK after publish failure")
+			// Pior caso: NACK também falhou (Rabbit channel já caiu). Delivery
+			// fica unacked, presa até channel reset / reconnect. Rabbit redelivers
+			// automaticamente quando o channel recovers, mas em CloudHub isso
+			// pode demorar segundos. Log Error explícito + event canônico permite
+			// alerting (e.g. CloudWatch/Splunk threshold) detectar acumulo em prod.
+			logger.WithError(nackErr).WithFields(logrus.Fields{
+				"event": "delivery_stuck_pending_redelivery",
+				"kind":  kind,
+			}).Error("Failed to NACK after publish failure — delivery unacked, awaiting Rabbit channel recovery")
 		}
 		return
 	}

--- a/internal/services/message_consumer.go
+++ b/internal/services/message_consumer.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"sync"
@@ -264,31 +265,43 @@ func (c *Consumer) processMessageWithRetry(ctx context.Context, msg amqp.Deliver
 	// Process the message
 	err := c.handler(msgCtx, msg)
 	if err != nil {
+		// Transient requeue: handler sinalizou condição esperada (e.g. phone-lock
+		// contention) que NÃO é falha. Republica preservando retryCount pra não
+		// queimar retry budget — caso contrário rajadas do mesmo cidadão iriam
+		// pra DLQ na primeira tentativa quando MaxRetries=-1.
+		var tr TransientRequeueError
+		if errors.As(err, &tr) {
+			delay := tr.TransientRequeueDelay()
+			logger.WithError(err).WithFields(logrus.Fields{
+				"retry_count": retryCount,
+				"delay":       delay,
+			}).Info("Transient requeue (not a processing failure); republishing without burning retry budget")
+			c.requeueWithDelay(ctx, msg, retryCount, delay, logger, "transient-requeue")
+			return
+		}
+
 		logger.WithError(err).WithField("retry_count", retryCount).Error("Message processing failed")
 
-		if retryCount >= maxRetries {
+		// maxRetries < 0 = infinitas tentativas (default RABBITMQ_MAX_RETRIES=-1).
+		// Sem o gate negativo, `retryCount(0) >= maxRetries(-1)` viraria true e
+		// toda primeira falha iria pra DLQ — invertendo a semântica documentada.
+		if maxRetries >= 0 && retryCount >= maxRetries {
 			logger.WithField("max_retries", maxRetries).Error("Message exceeded maximum retries, sending to DLQ")
-			// Send to DLQ
 			if err := msg.Reject(false); err != nil {
 				logger.WithError(err).Error("Failed to reject message to DLQ")
 			}
 			return
 		}
 
-		// Retry the message with exponential backoff
+		// Retry with exponential backoff. Sleep ctx-aware no consumer (não no
+		// handler) pra não bloquear shutdown e pra ter delay real — exchange é
+		// `direct` plain, header `x-delay` é ignorado.
 		retryDelay := time.Duration((retryCount+1)*(retryCount+1)) * time.Second
 		logger.WithFields(logrus.Fields{
 			"retry_count": retryCount + 1,
 			"retry_delay": retryDelay,
 		}).Info("Retrying message with delay")
-
-		// Publish retry message with increased retry count
-		c.publishRetryMessage(msg, retryCount+1, retryDelay, logger)
-
-		// Acknowledge original message
-		if err := msg.Ack(false); err != nil {
-			logger.WithError(err).Error("Failed to acknowledge message for retry")
-		}
+		c.requeueWithDelay(ctx, msg, retryCount+1, retryDelay, logger, "retry")
 		return
 	}
 
@@ -300,8 +313,66 @@ func (c *Consumer) processMessageWithRetry(ctx context.Context, msg amqp.Deliver
 	}
 }
 
-// publishRetryMessage publishes a message for retry with delay
-func (c *Consumer) publishRetryMessage(originalMsg amqp.Delivery, retryCount int64, delay time.Duration, logger *logrus.Entry) {
+// handleRequeueShutdown — NACK+requeue quando o backoff é interrompido
+// por shutdown (ctx ou stopChan). Mantém a mensagem na fila pra próxima
+// volta do worker reentregar.
+func (c *Consumer) handleRequeueShutdown(msg amqp.Delivery, kind, signal string, logger *logrus.Entry) {
+	logger.WithFields(logrus.Fields{"kind": kind, "signal": signal}).
+		Info("Requeue backoff interrupted by shutdown; nack+requeue")
+	if nackErr := msg.Nack(false, true); nackErr != nil {
+		logger.WithError(nackErr).Error("Failed to NACK during shutdown")
+	}
+}
+
+// requeueWithDelay aguarda `delay` (ctx-aware) e republica `msg` com o
+// `retryCount` informado. Se o backoff é interrompido por shutdown ou se o
+// republish falha, NACK-requeue pra Rabbit manter a mensagem na fila —
+// nunca ACK sem confirmar que a cópia republicada saiu da channel. O kind
+// é apenas pra log discriminar "retry" vs "transient-requeue".
+func (c *Consumer) requeueWithDelay(
+	ctx context.Context,
+	msg amqp.Delivery,
+	retryCount int64,
+	delay time.Duration,
+	logger *logrus.Entry,
+	kind string,
+) {
+	// Ouvir ctx.Done() + stopChan: cmd/worker registra consumer com
+	// context.Background(), então shutdown via StopAll fecha apenas
+	// stopChan. Sem o segundo case, backoff longo (especialmente com
+	// MaxRetries=-1 e quadratic delay) estoura a janela de graceful
+	// shutdown de 30s e deixa a delivery unacked até o kill.
+	select {
+	case <-time.After(delay):
+	case <-ctx.Done():
+		c.handleRequeueShutdown(msg, kind, "ctx.Done", logger)
+		return
+	case <-c.stopChan:
+		c.handleRequeueShutdown(msg, kind, "stopChan", logger)
+		return
+	}
+
+	if pubErr := c.publishRetryMessage(msg, retryCount, delay, logger); pubErr != nil {
+		// Republish falhou (channel/connection blip). ACKar agora perderia
+		// a mensagem permanentemente. NACK+requeue mantém na fila pra próxima
+		// volta — quando o channel recovers, Rabbit reentrega.
+		logger.WithError(pubErr).WithField("kind", kind).
+			Error("publishRetryMessage failed; nack+requeue pra evitar loss")
+		if nackErr := msg.Nack(false, true); nackErr != nil {
+			logger.WithError(nackErr).Error("Failed to NACK after publish failure")
+		}
+		return
+	}
+	if ackErr := msg.Ack(false); ackErr != nil {
+		logger.WithError(ackErr).WithField("kind", kind).
+			Error("Failed to acknowledge original message after successful republish")
+	}
+}
+
+// publishRetryMessage publishes a message for retry with delay.
+// Retorna erro pro caller decidir entre ACK (sucesso, original removível)
+// vs NACK-requeue (falha → manter na fila pra Rabbit retentar entrega).
+func (c *Consumer) publishRetryMessage(originalMsg amqp.Delivery, retryCount int64, delay time.Duration, logger *logrus.Entry) error {
 	// Prepare headers with retry information
 	headers := amqp.Table{
 		"x-retry-count": retryCount,
@@ -335,7 +406,9 @@ func (c *Consumer) publishRetryMessage(originalMsg amqp.Delivery, retryCount int
 
 	if err != nil {
 		logger.WithError(err).Error("Failed to publish retry message")
+		return err
 	}
+	return nil
 }
 
 // AddConsumer adds a new consumer to the manager

--- a/internal/services/meta_graph_service.go
+++ b/internal/services/meta_graph_service.go
@@ -1,0 +1,183 @@
+// Package services — Meta Graph API client for outbound WhatsApp Business
+// messages. POC scope (`feat/meta-direct-poc`): text-only send.
+//
+// Equivalente ao Mule `send-via-meta-graph-flow` em `webhook-flow.xml`. Quando
+// Gateway absorver completamente o Mule, este client cobrirá também media
+// upload + send (image/audio/video/document/sticker), location, template,
+// interactive — fase posterior do migration plan.
+//
+// Endpoint Meta:
+//
+//	POST https://graph.facebook.com/{api_version}/{phone_number_id}/messages
+//	Authorization: Bearer {system_user_token}
+//	Content-Type: application/json
+//
+// Retries: o caller (worker) já tem retry/backoff; este client só faz 1
+// tentativa por chamada. Erros 5xx do Meta retornam erro pro caller decidir.
+package services
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/prefeitura-rio/app-eai-agent-gateway/internal/config"
+)
+
+// MetaGraphService — client HTTP para Meta WhatsApp Business Cloud API.
+type MetaGraphService struct {
+	cfg        *config.MetaConfig
+	httpClient *http.Client
+	logger     *logrus.Logger
+}
+
+// NewMetaGraphService constrói o client. Timeout 15s alinhado com Mule
+// `send-via-meta-graph-flow` (config: 15s connect + 15s response).
+func NewMetaGraphService(cfg *config.MetaConfig, logger *logrus.Logger) *MetaGraphService {
+	return &MetaGraphService{
+		cfg: cfg,
+		httpClient: &http.Client{
+			Timeout: 15 * time.Second,
+		},
+		logger: logger,
+	}
+}
+
+// metaSendTextRequest — payload mínimo Meta /messages pra texto.
+type metaSendTextRequest struct {
+	MessagingProduct string          `json:"messaging_product"`
+	RecipientType    string          `json:"recipient_type"`
+	To               string          `json:"to"`
+	Type             string          `json:"type"`
+	Text             metaTextPayload `json:"text"`
+}
+
+type metaTextPayload struct {
+	PreviewURL bool   `json:"preview_url"`
+	Body       string `json:"body"`
+}
+
+// MetaSendResponse — shape do success response do Meta /messages.
+type MetaSendResponse struct {
+	MessagingProduct string                  `json:"messaging_product"`
+	Contacts         []MetaSendContactRef    `json:"contacts"`
+	Messages         []MetaSendMessageResult `json:"messages"`
+}
+
+// MetaSendContactRef — eco do destinatário (Meta normaliza).
+type MetaSendContactRef struct {
+	Input string `json:"input"`
+	WAID  string `json:"wa_id"`
+}
+
+// MetaSendMessageResult — id retornado por mensagem enviada (wamid).
+type MetaSendMessageResult struct {
+	ID string `json:"id"`
+}
+
+// SendText envia mensagem texto pro Meta Graph API.
+//
+// Retorna wamid em sucesso ou erro descritivo. Não faz retry — caller decide.
+// PII (texto) NUNCA aparece em log; só nome + len + status code.
+func (s *MetaGraphService) SendText(ctx context.Context, recipient, body string) (string, error) {
+	if !s.cfg.Enabled {
+		return "", fmt.Errorf("meta direct integration disabled (META_DIRECT_ENABLED=false)")
+	}
+	if s.cfg.SystemUserToken == "" || s.cfg.PhoneNumberID == "" {
+		return "", fmt.Errorf("meta credentials missing (SystemUserToken or PhoneNumberID empty)")
+	}
+	if recipient == "" || body == "" {
+		return "", fmt.Errorf("recipient and body must be non-empty")
+	}
+
+	reqBody := metaSendTextRequest{
+		MessagingProduct: "whatsapp",
+		RecipientType:    "individual",
+		To:               recipient,
+		Type:             "text",
+		Text:             metaTextPayload{PreviewURL: false, Body: body},
+	}
+
+	payload, err := json.Marshal(reqBody)
+	if err != nil {
+		return "", fmt.Errorf("marshal payload: %w", err)
+	}
+
+	url := fmt.Sprintf(
+		"https://graph.facebook.com/%s/%s/messages",
+		s.cfg.GraphAPIVersion, s.cfg.PhoneNumberID,
+	)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(payload))
+	if err != nil {
+		return "", fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+s.cfg.SystemUserToken)
+	req.Header.Set("Content-Type", "application/json")
+
+	start := time.Now()
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		s.logger.WithFields(logrus.Fields{
+			"event":    "meta_graph_send_error",
+			"recipient_prefix": recipientPrefix(recipient),
+			"duration_ms":      time.Since(start).Milliseconds(),
+			"error":            err.Error(),
+		}).Error("Meta Graph send failed")
+		return "", fmt.Errorf("http send: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(resp.Body)
+
+	logFields := logrus.Fields{
+		"event":            "meta_graph_send",
+		"recipient_prefix": recipientPrefix(recipient),
+		"status_code":      resp.StatusCode,
+		"duration_ms":      time.Since(start).Milliseconds(),
+		"body_length":      len(body),
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		// Snippet do erro pra debug — Meta retorna error.message útil mas
+		// pode conter PII; truncar pra primeiros 200 chars.
+		errSnippet := string(respBody)
+		if len(errSnippet) > 200 {
+			errSnippet = errSnippet[:200] + "...(truncated)"
+		}
+		logFields["error_body"] = errSnippet
+		s.logger.WithFields(logFields).Error("Meta Graph send non-2xx")
+		return "", fmt.Errorf("meta returned status %d: %s", resp.StatusCode, errSnippet)
+	}
+
+	var sendResp MetaSendResponse
+	if err := json.Unmarshal(respBody, &sendResp); err != nil {
+		s.logger.WithFields(logFields).WithError(err).Error("Meta Graph response parse failed")
+		return "", fmt.Errorf("parse response: %w", err)
+	}
+
+	if len(sendResp.Messages) == 0 || sendResp.Messages[0].ID == "" {
+		s.logger.WithFields(logFields).Warn("Meta Graph success response without wamid")
+		return "", fmt.Errorf("no wamid in response")
+	}
+
+	wamid := sendResp.Messages[0].ID
+	logFields["wamid"] = wamid
+	s.logger.WithFields(logFields).Info("Meta Graph send success")
+	return wamid, nil
+}
+
+// recipientPrefix mascara telefone pra log (LGPD/PII).
+// "5521965850470" → "55219658…" (8 chars + suffix).
+func recipientPrefix(phone string) string {
+	if len(phone) <= 8 {
+		return phone
+	}
+	return phone[:8] + "…"
+}

--- a/internal/services/meta_graph_service.go
+++ b/internal/services/meta_graph_service.go
@@ -19,9 +19,11 @@ package services
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
+	"mime/multipart"
 	"net/http"
 	"time"
 
@@ -29,6 +31,16 @@ import (
 
 	"github.com/prefeitura-rio/app-eai-agent-gateway/internal/config"
 )
+
+// DecodeBase64 é helper público pra callers decodificarem o base64 do
+// envelope antes de chamar UploadMedia. Centraliza pra evitar imports
+// extras em packages handlers.
+func DecodeBase64(s string) ([]byte, error) {
+	if s == "" {
+		return nil, fmt.Errorf("base64 string empty")
+	}
+	return base64.StdEncoding.DecodeString(s)
+}
 
 // MetaGraphService — client HTTP para Meta WhatsApp Business Cloud API.
 type MetaGraphService struct {
@@ -590,6 +602,100 @@ func (s *MetaGraphService) DownloadMedia(ctx context.Context, signedURL string, 
 		"duration_ms": time.Since(start).Milliseconds(),
 	}).Info("Meta media downloaded")
 	return bs, nil
+}
+
+// UploadMedia faz POST multipart pra `/{phone_number_id}/media` e retorna
+// o `media_id` (handle reusável em SendMedia.ID). Usado quando Engine emite
+// bytes inline (base64) que precisam ser servidos pelo Meta (sem URL pública).
+//
+// `mimeType` deve bater com `bytes` (Meta valida). `filename` é opcional —
+// Meta gera um nome default. `messaging_product=whatsapp` é fixado no body.
+//
+// Limites Meta (referência v21.0):
+//   - audio: 16 MB
+//   - image: 5 MB
+//   - video: 16 MB
+//   - document: 100 MB
+//
+// Bytes maiores que o cap ainda enviam (Meta retorna 4xx). Gateway não pre-
+// valida pra evitar duplicação — caller pode comparar `len(bytes)` antes.
+func (s *MetaGraphService) UploadMedia(ctx context.Context, mimeType string, content []byte, filename string) (string, error) {
+	if err := s.credentialsReady(); err != nil {
+		return "", err
+	}
+	if mimeType == "" {
+		return "", fmt.Errorf("mimeType required")
+	}
+	if len(content) == 0 {
+		return "", fmt.Errorf("content empty")
+	}
+	if filename == "" {
+		filename = "upload" // Meta aceita default; usado só pra debug header
+	}
+
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+	_ = writer.WriteField("messaging_product", "whatsapp")
+	_ = writer.WriteField("type", mimeType)
+	part, err := writer.CreateFormFile("file", filename)
+	if err != nil {
+		return "", fmt.Errorf("multipart create file part: %w", err)
+	}
+	if _, err := part.Write(content); err != nil {
+		return "", fmt.Errorf("multipart write content: %w", err)
+	}
+	if err := writer.Close(); err != nil {
+		return "", fmt.Errorf("multipart close: %w", err)
+	}
+
+	url := fmt.Sprintf(
+		"https://graph.facebook.com/%s/%s/media",
+		s.cfg.GraphAPIVersion, s.cfg.PhoneNumberID,
+	)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, body)
+	if err != nil {
+		return "", fmt.Errorf("create upload request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+s.cfg.SystemUserToken)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+
+	start := time.Now()
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		s.logger.WithError(err).WithFields(logrus.Fields{
+			"event":       "meta_media_upload_error",
+			"mime_type":   mimeType,
+			"bytes":       len(content),
+			"duration_ms": time.Since(start).Milliseconds(),
+		}).Error("Meta media upload failed")
+		return "", fmt.Errorf("upload http: %w", err)
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		snippet := string(respBody)
+		if len(snippet) > 200 {
+			snippet = snippet[:200] + "...(truncated)"
+		}
+		return "", fmt.Errorf("media upload status %d: %s", resp.StatusCode, snippet)
+	}
+	var parsed struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(respBody, &parsed); err != nil {
+		return "", fmt.Errorf("parse upload response: %w", err)
+	}
+	if parsed.ID == "" {
+		return "", fmt.Errorf("upload response missing id")
+	}
+	s.logger.WithFields(logrus.Fields{
+		"event":       "meta_media_upload_ok",
+		"media_id":    parsed.ID,
+		"mime_type":   mimeType,
+		"bytes":       len(content),
+		"duration_ms": time.Since(start).Milliseconds(),
+	}).Info("Meta media uploaded")
+	return parsed.ID, nil
 }
 
 // doSend é o transport comum: serializa, POST, parse wamid.

--- a/internal/services/meta_graph_service.go
+++ b/internal/services/meta_graph_service.go
@@ -195,6 +195,17 @@ func recipientPrefix(phone string) string {
 	return phone[:8] + "…"
 }
 
+// mediaIDPrefix mascara `meta_media_id` pra log. Não é PII strictly,
+// mas combinado com timestamps de inbound permite reconstruir
+// conversa-por-conversa. Por consistência LGPD, aplicar mesma redução.
+// "1234567890123456" → "12345678…" (8 chars + suffix).
+func mediaIDPrefix(mediaID string) string {
+	if len(mediaID) <= 8 {
+		return mediaID
+	}
+	return mediaID[:8] + "…"
+}
+
 // ─── Media outbound ──────────────────────────────────────────────────────
 //
 // Pattern Meta /messages pra media é:
@@ -521,7 +532,7 @@ func (s *MetaGraphService) LookupMedia(ctx context.Context, metaMediaID string) 
 	if err != nil {
 		s.logger.WithFields(logrus.Fields{
 			"event":         "meta_media_lookup_error",
-			"meta_media_id": metaMediaID,
+			"meta_media_id": mediaIDPrefix(metaMediaID),
 			"duration_ms":   time.Since(start).Milliseconds(),
 			"error":         err.Error(),
 		}).Error("Meta media lookup failed")
@@ -536,7 +547,7 @@ func (s *MetaGraphService) LookupMedia(ctx context.Context, metaMediaID string) 
 		}
 		s.logger.WithFields(logrus.Fields{
 			"event":         "meta_media_lookup_non_2xx",
-			"meta_media_id": metaMediaID,
+			"meta_media_id": mediaIDPrefix(metaMediaID),
 			"status_code":   resp.StatusCode,
 			"error_body":    snippet,
 		}).Error("Meta media lookup non-2xx")

--- a/internal/services/meta_graph_service.go
+++ b/internal/services/meta_graph_service.go
@@ -25,6 +25,7 @@ import (
 	"io"
 	"mime/multipart"
 	"net/http"
+	"net/textproto"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -637,7 +638,13 @@ func (s *MetaGraphService) UploadMedia(ctx context.Context, mimeType string, con
 	writer := multipart.NewWriter(body)
 	_ = writer.WriteField("messaging_product", "whatsapp")
 	_ = writer.WriteField("type", mimeType)
-	part, err := writer.CreateFormFile("file", filename)
+	// CreateFormFile usa application/octet-stream por default. Meta exige
+	// que o multipart file part tenha Content-Type igual ao `type` field;
+	// caso contrário, upload é rejeitado. Construir o MIMEHeader manualmente.
+	mh := make(textproto.MIMEHeader)
+	mh.Set("Content-Disposition", fmt.Sprintf(`form-data; name="file"; filename=%q`, filename))
+	mh.Set("Content-Type", mimeType)
+	part, err := writer.CreatePart(mh)
 	if err != nil {
 		return "", fmt.Errorf("multipart create file part: %w", err)
 	}

--- a/internal/services/meta_graph_service.go
+++ b/internal/services/meta_graph_service.go
@@ -181,3 +181,479 @@ func recipientPrefix(phone string) string {
 	}
 	return phone[:8] + "…"
 }
+
+// ─── Media outbound ──────────────────────────────────────────────────────
+//
+// Pattern Meta /messages pra media é:
+//
+//	{
+//	  "messaging_product": "whatsapp",
+//	  "to": "<phone>",
+//	  "type": "image|audio|video|document|sticker",
+//	  "<type>": { "id": "<media_id>" }                  // upload via /media
+//	         OR { "link": "https://..." }                // URL pública
+//	         + opcional "caption", "filename" (document)
+//	}
+//
+// `id` (via upload Meta /media) é preferível: payload menor, Meta dedupa,
+// pode reusar entre destinatários. `link` mais simples mas exige URL HTTPS
+// publicamente acessível (não vai funcionar via Cloud Run interno).
+//
+// `SendMedia` aceita ambos: passar `MediaInput.ID` OU `MediaInput.Link`.
+// Se ambos preenchidos, ID ganha precedência (Meta-side requirement).
+
+// MediaInput descreve a media a ser enviada. Use exatamente um de {ID, Link}.
+type MediaInput struct {
+	// ID é o media handle retornado por upload pra Meta /media (preferível).
+	ID string
+	// Link é uma URL HTTPS pública pro conteúdo (alternativa simples).
+	Link string
+	// Caption: opcional pra image/video/document; ignorado por audio/sticker.
+	Caption string
+	// Filename: opcional pra document.
+	Filename string
+	// Voice: opcional pra audio (true = voice note no WhatsApp).
+	Voice bool
+}
+
+type metaMediaSendRequest struct {
+	MessagingProduct string                 `json:"messaging_product"`
+	RecipientType    string                 `json:"recipient_type"`
+	To               string                 `json:"to"`
+	Type             string                 `json:"type"`
+	Image            *metaMediaPayload      `json:"image,omitempty"`
+	Audio            *metaMediaPayload      `json:"audio,omitempty"`
+	Video            *metaMediaPayload      `json:"video,omitempty"`
+	Document         *metaMediaPayload      `json:"document,omitempty"`
+	Sticker          *metaMediaPayload      `json:"sticker,omitempty"`
+	Location         *metaLocationPayload   `json:"location,omitempty"`
+	Template         *metaTemplatePayload   `json:"template,omitempty"`
+	Interactive      *metaInteractiveSend   `json:"interactive,omitempty"`
+	Reaction         *metaReactionPayload   `json:"reaction,omitempty"`
+	Context          *metaContextPayload    `json:"context,omitempty"`
+}
+
+type metaMediaPayload struct {
+	ID       string `json:"id,omitempty"`
+	Link     string `json:"link,omitempty"`
+	Caption  string `json:"caption,omitempty"`
+	Filename string `json:"filename,omitempty"`
+	Voice    bool   `json:"voice,omitempty"`
+}
+
+type metaLocationPayload struct {
+	Latitude  float64 `json:"latitude"`
+	Longitude float64 `json:"longitude"`
+	Name      string  `json:"name,omitempty"`
+	Address   string  `json:"address,omitempty"`
+}
+
+type metaTemplatePayload struct {
+	Name       string                       `json:"name"`
+	Language   metaTemplateLanguage         `json:"language"`
+	Components []map[string]interface{}     `json:"components,omitempty"`
+}
+
+type metaTemplateLanguage struct {
+	Code string `json:"code"`
+}
+
+type metaInteractiveSend struct {
+	Type   string                 `json:"type"`
+	Header map[string]interface{} `json:"header,omitempty"`
+	Body   map[string]interface{} `json:"body,omitempty"`
+	Footer map[string]interface{} `json:"footer,omitempty"`
+	Action map[string]interface{} `json:"action"`
+}
+
+type metaReactionPayload struct {
+	MessageID string `json:"message_id"`
+	Emoji     string `json:"emoji"`
+}
+
+type metaContextPayload struct {
+	MessageID string `json:"message_id"`
+}
+
+func (s *MetaGraphService) credentialsReady() error {
+	if !s.cfg.Enabled {
+		return fmt.Errorf("meta direct integration disabled (META_DIRECT_ENABLED=false)")
+	}
+	if s.cfg.SystemUserToken == "" || s.cfg.PhoneNumberID == "" {
+		return fmt.Errorf("meta credentials missing (SystemUserToken or PhoneNumberID empty)")
+	}
+	return nil
+}
+
+func mediaPayloadFromInput(in MediaInput) (*metaMediaPayload, error) {
+	if in.ID == "" && in.Link == "" {
+		return nil, fmt.Errorf("media requires either id or link")
+	}
+	p := &metaMediaPayload{
+		Caption:  in.Caption,
+		Filename: in.Filename,
+		Voice:    in.Voice,
+	}
+	if in.ID != "" {
+		p.ID = in.ID
+	} else {
+		p.Link = in.Link
+	}
+	return p, nil
+}
+
+// SendMedia envia image/audio/video/document/sticker pro Meta.
+// `mediaType` deve ser um dos: "image","audio","video","document","sticker".
+func (s *MetaGraphService) SendMedia(ctx context.Context, recipient, mediaType string, in MediaInput) (string, error) {
+	if err := s.credentialsReady(); err != nil {
+		return "", err
+	}
+	if recipient == "" {
+		return "", fmt.Errorf("recipient must be non-empty")
+	}
+	allowed := map[string]bool{"image": true, "audio": true, "video": true, "document": true, "sticker": true}
+	if !allowed[mediaType] {
+		return "", fmt.Errorf("invalid mediaType %q", mediaType)
+	}
+	payload, err := mediaPayloadFromInput(in)
+	if err != nil {
+		return "", err
+	}
+	// Caption só vale pra image/video/document.
+	if mediaType == "audio" || mediaType == "sticker" {
+		payload.Caption = ""
+		payload.Filename = ""
+	}
+	// Voice só vale pra audio.
+	if mediaType != "audio" {
+		payload.Voice = false
+	}
+	req := metaMediaSendRequest{
+		MessagingProduct: "whatsapp",
+		RecipientType:    "individual",
+		To:               recipient,
+		Type:             mediaType,
+	}
+	switch mediaType {
+	case "image":
+		req.Image = payload
+	case "audio":
+		req.Audio = payload
+	case "video":
+		req.Video = payload
+	case "document":
+		req.Document = payload
+	case "sticker":
+		req.Sticker = payload
+	}
+	return s.doSend(ctx, recipient, mediaType, req)
+}
+
+// SendLocation envia coordenadas (anexo "Localização" no WhatsApp).
+func (s *MetaGraphService) SendLocation(ctx context.Context, recipient string, lat, lng float64, name, address string) (string, error) {
+	if err := s.credentialsReady(); err != nil {
+		return "", err
+	}
+	if recipient == "" {
+		return "", fmt.Errorf("recipient must be non-empty")
+	}
+	req := metaMediaSendRequest{
+		MessagingProduct: "whatsapp",
+		RecipientType:    "individual",
+		To:               recipient,
+		Type:             "location",
+		Location: &metaLocationPayload{
+			Latitude: lat, Longitude: lng, Name: name, Address: address,
+		},
+	}
+	return s.doSend(ctx, recipient, "location", req)
+}
+
+// SendTemplate envia template aprovado pelo Meta (uso pra mensagens proativas
+// fora da janela 24h ou pra HSM transactional). `components` deve seguir
+// o shape Meta — typicamente:
+//
+//	[
+//	  { "type":"header", "parameters":[ ... ] },
+//	  { "type":"body",   "parameters":[ {"type":"text","text":"..."} ] }
+//	]
+func (s *MetaGraphService) SendTemplate(ctx context.Context, recipient, name, langCode string, components []map[string]interface{}) (string, error) {
+	if err := s.credentialsReady(); err != nil {
+		return "", err
+	}
+	if recipient == "" || name == "" || langCode == "" {
+		return "", fmt.Errorf("recipient, template name, and language code required")
+	}
+	req := metaMediaSendRequest{
+		MessagingProduct: "whatsapp",
+		RecipientType:    "individual",
+		To:               recipient,
+		Type:             "template",
+		Template: &metaTemplatePayload{
+			Name:       name,
+			Language:   metaTemplateLanguage{Code: langCode},
+			Components: components,
+		},
+	}
+	return s.doSend(ctx, recipient, "template", req)
+}
+
+// SendInteractive envia button/list/flow message. `action` é obrigatório pelo
+// Meta — formato depende do subtype:
+//
+//	button:        action.buttons = [{ type:"reply", reply:{id, title}}, ...]
+//	list:          action.button = "..."; action.sections = [...]
+//	product:       action.catalog_id, action.product_retailer_id
+//	flow:          action.parameters = { flow_token, flow_id, flow_cta, ... }
+//
+// `subtype` valida apenas valores conhecidos do Meta API; demais campos
+// passam-through como caller passou (Engine monta o shape correto).
+func (s *MetaGraphService) SendInteractive(ctx context.Context, recipient, subtype string, header, body, footer, action map[string]interface{}) (string, error) {
+	if err := s.credentialsReady(); err != nil {
+		return "", err
+	}
+	if recipient == "" || subtype == "" {
+		return "", fmt.Errorf("recipient and subtype required")
+	}
+	if action == nil {
+		return "", fmt.Errorf("interactive.action is required by Meta")
+	}
+	allowed := map[string]bool{"button": true, "list": true, "product": true, "product_list": true, "flow": true}
+	if !allowed[subtype] {
+		return "", fmt.Errorf("invalid interactive subtype %q", subtype)
+	}
+	req := metaMediaSendRequest{
+		MessagingProduct: "whatsapp",
+		RecipientType:    "individual",
+		To:               recipient,
+		Type:             "interactive",
+		Interactive: &metaInteractiveSend{
+			Type:   subtype,
+			Header: header,
+			Body:   body,
+			Footer: footer,
+			Action: action,
+		},
+	}
+	return s.doSend(ctx, recipient, "interactive_"+subtype, req)
+}
+
+// SendReaction envia emoji reaction a mensagem prévia. `wamid` é o ID da
+// mensagem alvo; `emoji` é o caractere unicode (string vazia remove a reaction).
+func (s *MetaGraphService) SendReaction(ctx context.Context, recipient, wamid, emoji string) (string, error) {
+	if err := s.credentialsReady(); err != nil {
+		return "", err
+	}
+	if recipient == "" || wamid == "" {
+		return "", fmt.Errorf("recipient and wamid required")
+	}
+	req := metaMediaSendRequest{
+		MessagingProduct: "whatsapp",
+		RecipientType:    "individual",
+		To:               recipient,
+		Type:             "reaction",
+		Reaction: &metaReactionPayload{
+			MessageID: wamid,
+			Emoji:     emoji,
+		},
+	}
+	return s.doSend(ctx, recipient, "reaction", req)
+}
+
+// ─── Media download (inbound media bytes) ────────────────────────────────
+//
+// Meta hosts media inbound em CDN privada que expira em 5min. Pra Engine
+// processar imagem/áudio/vídeo, Gateway precisa:
+//
+//   1. GET https://graph.facebook.com/{v}/{media_id}
+//      → { url: "<signed_url>", mime_type, sha256, file_size, ... }
+//   2. GET <signed_url> com Authorization: Bearer {token}
+//      → bytes
+//
+// Resultado vai pro Engine via Vision/Audio MCP tools que aceitam tanto
+// `meta_media_id` (downloaded server-side) quanto bytes diretos. POC: só
+// expomos os primitivos; quem consome (worker, MCP) decide quando baixar.
+
+// MetaMediaMetadata é o retorno do step 1 (metadata lookup).
+type MetaMediaMetadata struct {
+	URL          string `json:"url"`
+	MimeType     string `json:"mime_type"`
+	SHA256       string `json:"sha256"`
+	FileSize     int64  `json:"file_size"`
+	ID           string `json:"id"`
+	MessagingProduct string `json:"messaging_product"`
+}
+
+// LookupMedia faz step 1 (metadata + signed URL). NÃO baixa bytes — caller
+// decide se chama DownloadMedia(URL) ou se passa URL pro MCP fazer.
+//
+// `metaMediaID` é o `id` retornado pelo webhook em
+// messages[i].image.id (ou audio.id, video.id, etc.).
+func (s *MetaGraphService) LookupMedia(ctx context.Context, metaMediaID string) (*MetaMediaMetadata, error) {
+	if err := s.credentialsReady(); err != nil {
+		return nil, err
+	}
+	if metaMediaID == "" {
+		return nil, fmt.Errorf("metaMediaID required")
+	}
+	url := fmt.Sprintf("https://graph.facebook.com/%s/%s", s.cfg.GraphAPIVersion, metaMediaID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create lookup request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+s.cfg.SystemUserToken)
+
+	start := time.Now()
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		s.logger.WithFields(logrus.Fields{
+			"event":         "meta_media_lookup_error",
+			"meta_media_id": metaMediaID,
+			"duration_ms":   time.Since(start).Milliseconds(),
+			"error":         err.Error(),
+		}).Error("Meta media lookup failed")
+		return nil, fmt.Errorf("lookup http: %w", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		snippet := string(body)
+		if len(snippet) > 200 {
+			snippet = snippet[:200] + "...(truncated)"
+		}
+		s.logger.WithFields(logrus.Fields{
+			"event":         "meta_media_lookup_non_2xx",
+			"meta_media_id": metaMediaID,
+			"status_code":   resp.StatusCode,
+			"error_body":    snippet,
+		}).Error("Meta media lookup non-2xx")
+		return nil, fmt.Errorf("media lookup status %d: %s", resp.StatusCode, snippet)
+	}
+	var meta MetaMediaMetadata
+	if err := json.Unmarshal(body, &meta); err != nil {
+		return nil, fmt.Errorf("parse media metadata: %w", err)
+	}
+	if meta.URL == "" {
+		return nil, fmt.Errorf("media metadata missing url")
+	}
+	s.logger.WithFields(logrus.Fields{
+		"event":         "meta_media_lookup_ok",
+		"meta_media_id": metaMediaID,
+		"mime_type":     meta.MimeType,
+		"file_size":     meta.FileSize,
+		"duration_ms":   time.Since(start).Milliseconds(),
+	}).Info("Meta media lookup ok")
+	return &meta, nil
+}
+
+// DownloadMedia faz step 2 (GET signed URL) e retorna os bytes. URL deve
+// ter sido obtida via LookupMedia logo antes (TTL ~5min).
+//
+// Limite de tamanho: cap em `maxBytes` pra evitar DoS via media gigante.
+// Passe 0 pra desabilitar cap (não recomendado em prod).
+func (s *MetaGraphService) DownloadMedia(ctx context.Context, signedURL string, maxBytes int64) ([]byte, error) {
+	if err := s.credentialsReady(); err != nil {
+		return nil, err
+	}
+	if signedURL == "" {
+		return nil, fmt.Errorf("signedURL required")
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, signedURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create download request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+s.cfg.SystemUserToken)
+	start := time.Now()
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("download http: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 256))
+		return nil, fmt.Errorf("media download status %d: %s", resp.StatusCode, string(body))
+	}
+	var reader io.Reader = resp.Body
+	if maxBytes > 0 {
+		reader = io.LimitReader(resp.Body, maxBytes+1)
+	}
+	bs, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, fmt.Errorf("read body: %w", err)
+	}
+	if maxBytes > 0 && int64(len(bs)) > maxBytes {
+		return nil, fmt.Errorf("media exceeds max bytes (%d > %d)", len(bs), maxBytes)
+	}
+	s.logger.WithFields(logrus.Fields{
+		"event":       "meta_media_download_ok",
+		"bytes":       len(bs),
+		"duration_ms": time.Since(start).Milliseconds(),
+	}).Info("Meta media downloaded")
+	return bs, nil
+}
+
+// doSend é o transport comum: serializa, POST, parse wamid.
+// Espelha SendText mas é genérico (qualquer metaMediaSendRequest).
+func (s *MetaGraphService) doSend(ctx context.Context, recipient, kind string, req metaMediaSendRequest) (string, error) {
+	payload, err := json.Marshal(req)
+	if err != nil {
+		return "", fmt.Errorf("marshal payload: %w", err)
+	}
+	url := fmt.Sprintf(
+		"https://graph.facebook.com/%s/%s/messages",
+		s.cfg.GraphAPIVersion, s.cfg.PhoneNumberID,
+	)
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(payload))
+	if err != nil {
+		return "", fmt.Errorf("create request: %w", err)
+	}
+	httpReq.Header.Set("Authorization", "Bearer "+s.cfg.SystemUserToken)
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	start := time.Now()
+	resp, err := s.httpClient.Do(httpReq)
+	if err != nil {
+		s.logger.WithFields(logrus.Fields{
+			"event":            "meta_graph_send_error",
+			"kind":             kind,
+			"recipient_prefix": recipientPrefix(recipient),
+			"duration_ms":      time.Since(start).Milliseconds(),
+			"error":            err.Error(),
+		}).Error("Meta Graph send failed")
+		return "", fmt.Errorf("http send: %w", err)
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+
+	logFields := logrus.Fields{
+		"event":            "meta_graph_send",
+		"kind":             kind,
+		"recipient_prefix": recipientPrefix(recipient),
+		"status_code":      resp.StatusCode,
+		"duration_ms":      time.Since(start).Milliseconds(),
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		errSnippet := string(respBody)
+		if len(errSnippet) > 200 {
+			errSnippet = errSnippet[:200] + "...(truncated)"
+		}
+		logFields["error_body"] = errSnippet
+		s.logger.WithFields(logFields).Error("Meta Graph send non-2xx")
+		return "", fmt.Errorf("meta returned status %d: %s", resp.StatusCode, errSnippet)
+	}
+
+	var sendResp MetaSendResponse
+	if err := json.Unmarshal(respBody, &sendResp); err != nil {
+		s.logger.WithFields(logFields).WithError(err).Error("Meta Graph response parse failed")
+		return "", fmt.Errorf("parse response: %w", err)
+	}
+	if len(sendResp.Messages) == 0 || sendResp.Messages[0].ID == "" {
+		s.logger.WithFields(logFields).Warn("Meta Graph success response without wamid")
+		return "", fmt.Errorf("no wamid in response")
+	}
+	wamid := sendResp.Messages[0].ID
+	logFields["wamid"] = wamid
+	s.logger.WithFields(logFields).Info("Meta Graph send success")
+	return wamid, nil
+}

--- a/internal/services/meta_graph_service_test.go
+++ b/internal/services/meta_graph_service_test.go
@@ -1,0 +1,154 @@
+package services
+
+import (
+	"context"
+	stdio "io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/prefeitura-rio/app-eai-agent-gateway/internal/config"
+)
+
+func newSilentLogger() *logrus.Logger {
+	l := logrus.New()
+	l.SetOutput(stdio.Discard)
+	return l
+}
+
+// fakeMetaServer permite injetar URL local pro client. Como o client
+// constrói URL via cfg.PhoneNumberID + graph.facebook.com, precisamos
+// substituir o transport pra interceptar.
+func newClientWithStubURL(stubURL string, cfg *config.MetaConfig) *MetaGraphService {
+	return &MetaGraphService{
+		cfg:        cfg,
+		httpClient: &http.Client{Transport: &stubTransport{stubURL: stubURL}},
+		logger:     newSilentLogger(),
+	}
+}
+
+// stubTransport redireciona qualquer request pro stubURL preservando method
+// e body. Permite o Service "achar" que está falando com Meta.
+type stubTransport struct{ stubURL string }
+
+func (s *stubTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	newReq := req.Clone(req.Context())
+	parsed, err := http.NewRequest(req.Method, s.stubURL, req.Body)
+	if err != nil {
+		return nil, err
+	}
+	parsed.Header = newReq.Header
+	return http.DefaultTransport.RoundTrip(parsed)
+}
+
+func baseCfg() *config.MetaConfig {
+	return &config.MetaConfig{
+		Enabled:         true,
+		AppSecret:       "secret",
+		VerifyToken:     "verify",
+		SystemUserToken: "tok",
+		PhoneNumberID:   "ph123",
+		GraphAPIVersion: "v21.0",
+	}
+}
+
+func TestSendText_DisabledFlag(t *testing.T) {
+	cfg := baseCfg()
+	cfg.Enabled = false
+	svc := NewMetaGraphService(cfg, newSilentLogger())
+	_, err := svc.SendText(context.Background(), "55", "hi")
+	if err == nil || !strings.Contains(err.Error(), "disabled") {
+		t.Errorf("expected disabled error, got %v", err)
+	}
+}
+
+func TestSendText_MissingCredentials(t *testing.T) {
+	cfg := baseCfg()
+	cfg.SystemUserToken = ""
+	svc := NewMetaGraphService(cfg, newSilentLogger())
+	_, err := svc.SendText(context.Background(), "55", "hi")
+	if err == nil || !strings.Contains(err.Error(), "credentials missing") {
+		t.Errorf("expected credentials missing, got %v", err)
+	}
+}
+
+func TestSendText_EmptyInputs(t *testing.T) {
+	cfg := baseCfg()
+	svc := NewMetaGraphService(cfg, newSilentLogger())
+	_, err := svc.SendText(context.Background(), "", "x")
+	if err == nil {
+		t.Error("expected error empty recipient")
+	}
+	_, err = svc.SendText(context.Background(), "55", "")
+	if err == nil {
+		t.Error("expected error empty body")
+	}
+}
+
+func TestSendText_HappyPath(t *testing.T) {
+	stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.Header.Get("Authorization") != "Bearer tok" {
+			t.Errorf("expected bearer tok, got %q", r.Header.Get("Authorization"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"messaging_product": "whatsapp",
+			"contacts": [{"input": "55", "wa_id": "55"}],
+			"messages": [{"id": "wamid.ABC"}]
+		}`))
+	}))
+	defer stub.Close()
+
+	svc := newClientWithStubURL(stub.URL, baseCfg())
+	wamid, err := svc.SendText(context.Background(), "55", "Olá")
+	if err != nil {
+		t.Fatalf("expected ok, got %v", err)
+	}
+	if wamid != "wamid.ABC" {
+		t.Errorf("expected wamid.ABC, got %q", wamid)
+	}
+}
+
+func TestSendText_MetaErrorStatus(t *testing.T) {
+	stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error": {"message": "blocked", "code": 200}}`))
+	}))
+	defer stub.Close()
+
+	svc := newClientWithStubURL(stub.URL, baseCfg())
+	_, err := svc.SendText(context.Background(), "55", "x")
+	if err == nil || !strings.Contains(err.Error(), "403") {
+		t.Errorf("expected 403 error, got %v", err)
+	}
+}
+
+func TestSendText_MissingWAMID(t *testing.T) {
+	stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"messages": []}`))
+	}))
+	defer stub.Close()
+
+	svc := newClientWithStubURL(stub.URL, baseCfg())
+	_, err := svc.SendText(context.Background(), "55", "x")
+	if err == nil || !strings.Contains(err.Error(), "no wamid") {
+		t.Errorf("expected no wamid error, got %v", err)
+	}
+}
+
+func TestRecipientPrefix(t *testing.T) {
+	if got := recipientPrefix("5521965850470"); got != "55219658…" {
+		t.Errorf("expected mask, got %q", got)
+	}
+	if got := recipientPrefix("123"); got != "123" {
+		t.Errorf("short phone returned as-is, got %q", got)
+	}
+}

--- a/internal/services/meta_graph_service_test.go
+++ b/internal/services/meta_graph_service_test.go
@@ -152,3 +152,219 @@ func TestRecipientPrefix(t *testing.T) {
 		t.Errorf("short phone returned as-is, got %q", got)
 	}
 }
+
+// ─── Media outbound ────────────────────────────────────────────────────────
+
+func TestSendMedia_HappyPath(t *testing.T) {
+	stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := stdio.ReadAll(r.Body)
+		s := string(body)
+		if !strings.Contains(s, `"type":"image"`) {
+			t.Errorf("expected type=image in body, got %s", s)
+		}
+		if !strings.Contains(s, `"id":"media-xyz"`) {
+			t.Errorf("expected media id in body, got %s", s)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"messages":[{"id":"wamid.IMG"}]}`))
+	}))
+	defer stub.Close()
+
+	svc := newClientWithStubURL(stub.URL, baseCfg())
+	wamid, err := svc.SendMedia(context.Background(), "5521", "image", MediaInput{ID: "media-xyz", Caption: "foto"})
+	if err != nil {
+		t.Fatalf("expected ok, got %v", err)
+	}
+	if wamid != "wamid.IMG" {
+		t.Errorf("expected wamid.IMG, got %q", wamid)
+	}
+}
+
+func TestSendMedia_InvalidType(t *testing.T) {
+	svc := NewMetaGraphService(baseCfg(), newSilentLogger())
+	_, err := svc.SendMedia(context.Background(), "5521", "garbage", MediaInput{ID: "x"})
+	if err == nil || !strings.Contains(err.Error(), "invalid mediaType") {
+		t.Errorf("expected invalid mediaType, got %v", err)
+	}
+}
+
+func TestSendMedia_RequiresIDOrLink(t *testing.T) {
+	svc := NewMetaGraphService(baseCfg(), newSilentLogger())
+	_, err := svc.SendMedia(context.Background(), "5521", "image", MediaInput{})
+	if err == nil || !strings.Contains(err.Error(), "id or link") {
+		t.Errorf("expected id-or-link error, got %v", err)
+	}
+}
+
+func TestSendLocation_HappyPath(t *testing.T) {
+	stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := stdio.ReadAll(r.Body)
+		s := string(body)
+		if !strings.Contains(s, `"type":"location"`) {
+			t.Errorf("expected location type, got %s", s)
+		}
+		if !strings.Contains(s, `"latitude":-22.9`) {
+			t.Errorf("expected latitude in body, got %s", s)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"messages":[{"id":"wamid.LOC"}]}`))
+	}))
+	defer stub.Close()
+
+	svc := newClientWithStubURL(stub.URL, baseCfg())
+	wamid, err := svc.SendLocation(context.Background(), "5521", -22.9, -43.2, "Praça", "Centro")
+	if err != nil || wamid != "wamid.LOC" {
+		t.Errorf("expected wamid.LOC ok, got wamid=%q err=%v", wamid, err)
+	}
+}
+
+func TestSendTemplate_HappyPath(t *testing.T) {
+	stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := stdio.ReadAll(r.Body)
+		s := string(body)
+		if !strings.Contains(s, `"name":"hello_world"`) {
+			t.Errorf("expected template name in body, got %s", s)
+		}
+		if !strings.Contains(s, `"code":"pt_BR"`) {
+			t.Errorf("expected language code in body, got %s", s)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"messages":[{"id":"wamid.TPL"}]}`))
+	}))
+	defer stub.Close()
+
+	svc := newClientWithStubURL(stub.URL, baseCfg())
+	wamid, err := svc.SendTemplate(context.Background(), "5521", "hello_world", "pt_BR", nil)
+	if err != nil || wamid != "wamid.TPL" {
+		t.Errorf("expected wamid.TPL, got wamid=%q err=%v", wamid, err)
+	}
+}
+
+func TestSendInteractive_RequiresAction(t *testing.T) {
+	svc := NewMetaGraphService(baseCfg(), newSilentLogger())
+	_, err := svc.SendInteractive(context.Background(), "5521", "button", nil, nil, nil, nil)
+	if err == nil || !strings.Contains(err.Error(), "action") {
+		t.Errorf("expected action required error, got %v", err)
+	}
+}
+
+func TestSendInteractive_HappyPath(t *testing.T) {
+	stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := stdio.ReadAll(r.Body)
+		s := string(body)
+		if !strings.Contains(s, `"type":"interactive"`) {
+			t.Errorf("expected interactive type, got %s", s)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"messages":[{"id":"wamid.INT"}]}`))
+	}))
+	defer stub.Close()
+
+	svc := newClientWithStubURL(stub.URL, baseCfg())
+	action := map[string]interface{}{
+		"buttons": []map[string]interface{}{
+			{"type": "reply", "reply": map[string]string{"id": "yes", "title": "Sim"}},
+		},
+	}
+	wamid, err := svc.SendInteractive(context.Background(), "5521", "button",
+		nil, map[string]interface{}{"text": "Confirma?"}, nil, action)
+	if err != nil || wamid != "wamid.INT" {
+		t.Errorf("expected wamid.INT, got wamid=%q err=%v", wamid, err)
+	}
+}
+
+func TestSendReaction_HappyPath(t *testing.T) {
+	stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := stdio.ReadAll(r.Body)
+		s := string(body)
+		if !strings.Contains(s, `"emoji":"❤️"`) {
+			t.Errorf("expected emoji in body, got %s", s)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"messages":[{"id":"wamid.REACT"}]}`))
+	}))
+	defer stub.Close()
+
+	svc := newClientWithStubURL(stub.URL, baseCfg())
+	wamid, err := svc.SendReaction(context.Background(), "5521", "wamid.PREV", "❤️")
+	if err != nil || wamid != "wamid.REACT" {
+		t.Errorf("expected wamid.REACT, got wamid=%q err=%v", wamid, err)
+	}
+}
+
+// ─── Media download ────────────────────────────────────────────────────────
+
+func TestLookupMedia_HappyPath(t *testing.T) {
+	stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer tok" {
+			t.Errorf("expected bearer tok, got %q", r.Header.Get("Authorization"))
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"url": "https://meta-cdn.example/signed",
+			"mime_type": "image/jpeg",
+			"sha256": "abc",
+			"file_size": 1234,
+			"id": "media-id-1",
+			"messaging_product": "whatsapp"
+		}`))
+	}))
+	defer stub.Close()
+
+	svc := newClientWithStubURL(stub.URL, baseCfg())
+	meta, err := svc.LookupMedia(context.Background(), "media-id-1")
+	if err != nil {
+		t.Fatalf("expected ok, got %v", err)
+	}
+	if meta.URL != "https://meta-cdn.example/signed" {
+		t.Errorf("expected signed url, got %q", meta.URL)
+	}
+	if meta.FileSize != 1234 {
+		t.Errorf("expected file_size=1234, got %d", meta.FileSize)
+	}
+}
+
+func TestLookupMedia_NonOKStatus(t *testing.T) {
+	stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":"media not found"}`))
+	}))
+	defer stub.Close()
+
+	svc := newClientWithStubURL(stub.URL, baseCfg())
+	_, err := svc.LookupMedia(context.Background(), "bad-id")
+	if err == nil || !strings.Contains(err.Error(), "404") {
+		t.Errorf("expected 404 error, got %v", err)
+	}
+}
+
+func TestDownloadMedia_HappyPath(t *testing.T) {
+	want := []byte("fake-bytes-content")
+	stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(want)
+	}))
+	defer stub.Close()
+
+	svc := newClientWithStubURL(stub.URL, baseCfg())
+	bs, err := svc.DownloadMedia(context.Background(), stub.URL, 1<<20) // 1MB cap
+	if err != nil {
+		t.Fatalf("expected ok, got %v", err)
+	}
+	if string(bs) != string(want) {
+		t.Errorf("bytes mismatch: got %s want %s", string(bs), string(want))
+	}
+}
+
+func TestDownloadMedia_ExceedsMax(t *testing.T) {
+	stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(make([]byte, 100))
+	}))
+	defer stub.Close()
+
+	svc := newClientWithStubURL(stub.URL, baseCfg())
+	_, err := svc.DownloadMedia(context.Background(), stub.URL, 10) // cap menor que body
+	if err == nil || !strings.Contains(err.Error(), "exceeds max bytes") {
+		t.Errorf("expected exceeds max bytes error, got %v", err)
+	}
+}

--- a/internal/services/redis_service.go
+++ b/internal/services/redis_service.go
@@ -288,6 +288,32 @@ func (r *RedisService) AcquireLock(ctx context.Context, key, holder string, ttl 
 	return ok, nil
 }
 
+// RenewLock estende TTL apenas se o caller ainda é o titular (Compare-And-
+// Set via Lua atômico). Retorna true se renovou, false se outro processo
+// pegou o lock (TTL expirou). Use periodicamente enquanto processamento
+// estiver vivo pra evitar lock expirar mid-operation.
+func (r *RedisService) RenewLock(ctx context.Context, key, holder string, ttl time.Duration) (bool, error) {
+	r.recordOperation()
+	// CAS: só renova se holder atual bate. Lua atômico garante que
+	// renovação não roba lock após expiração + reacquire por outro.
+	const script = `
+		if redis.call("get", KEYS[1]) == ARGV[1] then
+			return redis.call("pexpire", KEYS[1], ARGV[2])
+		else
+			return 0
+		end`
+	ms := ttl.Milliseconds()
+	res, err := r.client.Eval(ctx, script, []string{key}, holder, ms).Result()
+	if err != nil {
+		r.recordError()
+		return false, fmt.Errorf("redis renew lock error: %w", err)
+	}
+	if n, ok := res.(int64); ok && n == 1 {
+		return true, nil
+	}
+	return false, nil
+}
+
 // ReleaseLock libera o mutex apenas se o caller é o titular (Compare-And-
 // Delete via Lua atômico). Retorna ErrLockNotHeld se valor atual difere
 // (outro processo tomou posse após TTL).

--- a/internal/services/redis_service.go
+++ b/internal/services/redis_service.go
@@ -249,6 +249,69 @@ func (r *RedisService) Set(ctx context.Context, key string, value string, ttl ti
 // stale/evicted como erro fatal.
 var ErrKeyNotFound = errors.New("redis key not found")
 
+// ErrLockNotHeld — sentinel retornado por ReleaseLock quando o holder
+// passado não bate com o titular atual do lock. Indica perda de propriedade
+// (TTL expirou e outro adquiriu) ou bug de caller. Não-fatal — caller
+// normalmente loga e continua.
+var ErrLockNotHeld = errors.New("lock not held by caller")
+
+// AcquireLock tenta adquirir um mutex distribuído `key` válido por `ttl`.
+// Retorna true se o caller passou a ser o titular. Holder único (ex: uuid
+// gerado pelo worker) é guardado pra ReleaseLock garantir que só o titular
+// solta o lock (defesa contra release acidental por outro processo após
+// TTL).
+//
+// Uso típico (worker per-phone serialization):
+//
+//	holder := uuid.NewString()
+//	ok, err := r.AcquireLock(ctx, "phone:"+userNumber, holder, 30*time.Second)
+//	if err != nil || !ok { /* requeue */ }
+//	defer r.ReleaseLock(ctx, "phone:"+userNumber, holder)
+//	// process...
+//
+// Lock TTL deve cobrir o pior caso de processamento + retry window. Se
+// processo crashar, lock libera sozinho ao TTL expirar.
+func (r *RedisService) AcquireLock(ctx context.Context, key, holder string, ttl time.Duration) (bool, error) {
+	r.recordOperation()
+	ok, err := r.client.SetNX(ctx, key, holder, ttl).Result()
+	if err != nil {
+		r.recordError()
+		r.logger.WithError(err).WithFields(logrus.Fields{
+			"key": key,
+			"ttl": ttl,
+		}).Error("Failed to acquire lock in Redis")
+		return false, fmt.Errorf("redis acquire lock error: %w", err)
+	}
+	if ok {
+		r.recordSet()
+	}
+	return ok, nil
+}
+
+// ReleaseLock libera o mutex apenas se o caller é o titular (Compare-And-
+// Delete via Lua atômico). Retorna ErrLockNotHeld se valor atual difere
+// (outro processo tomou posse após TTL).
+func (r *RedisService) ReleaseLock(ctx context.Context, key, holder string) error {
+	r.recordOperation()
+	// CAD via Lua: garante atomicidade (Get + Del em uma operação) sem
+	// race entre check + delete.
+	const script = `
+		if redis.call("get", KEYS[1]) == ARGV[1] then
+			return redis.call("del", KEYS[1])
+		else
+			return 0
+		end`
+	res, err := r.client.Eval(ctx, script, []string{key}, holder).Result()
+	if err != nil {
+		r.recordError()
+		return fmt.Errorf("redis release lock error: %w", err)
+	}
+	if n, ok := res.(int64); ok && n == 1 {
+		return nil
+	}
+	return ErrLockNotHeld
+}
+
 // SetNX implementa SET key value NX EX ttl — claim atômico usado pra
 // idempotência (ex.: dedup wamid Meta webhook). Retorna true se claim foi
 // adquirida (chave não existia), false se já estava ocupada.

--- a/internal/services/redis_service.go
+++ b/internal/services/redis_service.go
@@ -3,6 +3,7 @@ package services
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -209,7 +210,7 @@ func (r *RedisService) Get(ctx context.Context, key string) (string, error) {
 	if err := result.Err(); err != nil {
 		if err == redis.Nil {
 			r.recordMiss()
-			return "", fmt.Errorf("key not found: %s", key)
+			return "", fmt.Errorf("%w: %s", ErrKeyNotFound, key)
 		}
 		r.recordError()
 		r.logger.WithError(err).WithField("key", key).Error("Failed to get value from Redis")
@@ -240,6 +241,37 @@ func (r *RedisService) SetValue(ctx context.Context, key string, value interface
 // Set stores a string value with TTL (implements interface)
 func (r *RedisService) Set(ctx context.Context, key string, value string, ttl time.Duration) error {
 	return r.SetValue(ctx, key, value, ttl)
+}
+
+// ErrKeyNotFound — sentinel retornado por Get quando a chave não existe.
+// Callers usam `errors.Is(err, services.ErrKeyNotFound)` pra discriminar
+// "miss esperado" de "Redis down". Sem isso, callers acabam classificando
+// stale/evicted como erro fatal.
+var ErrKeyNotFound = errors.New("redis key not found")
+
+// SetNX implementa SET key value NX EX ttl — claim atômico usado pra
+// idempotência (ex.: dedup wamid Meta webhook). Retorna true se claim foi
+// adquirida (chave não existia), false se já estava ocupada.
+//
+// A claim sobrevive `ttl` mesmo após processamento bem-sucedido; consumers
+// devem chamar SetNX *após* commit lógico (não antes) ou aceitar replay
+// indo até TTL expirar.
+func (r *RedisService) SetNX(ctx context.Context, key string, value string, ttl time.Duration) (bool, error) {
+	r.recordOperation()
+
+	ok, err := r.client.SetNX(ctx, key, value, ttl).Result()
+	if err != nil {
+		r.recordError()
+		r.logger.WithError(err).WithFields(logrus.Fields{
+			"key": key,
+			"ttl": ttl,
+		}).Error("Failed to SETNX in Redis")
+		return false, fmt.Errorf("redis setnx error: %w", err)
+	}
+	if ok {
+		r.recordSet()
+	}
+	return ok, nil
 }
 
 // Delete removes a key

--- a/internal/services/transient_requeue.go
+++ b/internal/services/transient_requeue.go
@@ -1,0 +1,19 @@
+package services
+
+import "time"
+
+// TransientRequeueError sinaliza que um handler de mensagem encontrou
+// uma condição esperada que justifica republish na própria fila, mas
+// NÃO conta como falha de processamento — ou seja, não incrementa o
+// retry counter nem aproxima a mensagem do DLQ.
+//
+// Caso de uso canônico: phone-lock contention quando duas mensagens do
+// mesmo cidadão chegam concorrentemente. Lock contention é fluxo normal
+// (operação serializada per-user), não falha de Engine/Redis.
+//
+// O consumer reconhece via errors.As e republica com o mesmo
+// retryCount + delay sugerido pelo handler.
+type TransientRequeueError interface {
+	error
+	TransientRequeueDelay() time.Duration
+}


### PR DESCRIPTION
## Summary

POC promovido pra **100% coverage** do path Gateway-direct (substitui Mule). Implementa o flow completo Meta → Gateway → Engine → Gateway → Meta sem dependência de Salesforce ou Mule.

**Feature flag default OFF (`META_DIRECT_ENABLED=false`)** — zero impacto produção até ativação explícita.

Companion: PR #20 (Mule SF-free gates) em `study-sf-whatsapp-poc1` permite testar SF-on vs SF-off no path Mule atual antes do cutover Gateway-direct.

## Conteúdo

### Inbound (Meta → Engine)
- `/meta/webhook` GET (verify) + POST (HMAC + parse + enqueue)
- Parse: text, image, audio, video, location, interactive (button_reply, list_reply, nfm_reply Flow)
- Idempotency atômica SETNX com sentinelas `inflight`/`done` — race-safe contra retries Meta concorrentes
- Anti-loop guard: drop mensagens da própria WABA (cascade bot→bot)
- Flow registry config-driven: `META_FLOW_REGISTRY="flow1:svc1;flow2:svc2"` → `metadata.service_name` + `metadata.form_submission` estruturado
- Status callbacks (delivered/read/failed) persistidos em Redis pra Engine consultar

### Outbound (Engine → Meta)
- `/meta/dispatch` recebe worker callback, roteia por type via envelope canônico
- `ExtractAgentMedia` parseia `tool_return_message` (send_whatsapp_media, generate_audio_response, send_whatsapp_flow/_buttons/_list)
- `MetaGraphService` cobre TODOS os tipos: SendText, SendMedia (image/audio/video/document/sticker), SendLocation, SendTemplate, SendInteractive, SendReaction, UploadMedia, LookupMedia, DownloadMedia
- Base64 inline → UploadMedia → SendMedia(ID) automático (caso `generate_audio_response`)
- Auth `X-Meta-Dispatch-Secret` header (fail-closed, header restrito ao SelfCallbackURL configurado)
- Send-once dedup atômico SETNX evita duplicate Meta delivery
- Distingue `ErrKeyNotFound` (404) vs Redis down (503) pra CallbackService classificar retriabilidade correto

### Concurrency safety
- Per-phone Redis lock (`worker:phone-lock:<user_number>`) com TTL = RabbitMQ.MessageTimeout
- Renewal goroutine via CAS Lua atômico (não rouba lock após perda)
- Contention timeout 10s → erro → RabbitMQ requeue

## Configurações novas

| Env | Default | Descrição |
|---|---|---|
| `META_DIRECT_ENABLED` | `false` | Feature flag master |
| `META_WEBHOOK_VERIFY_TOKEN` | — | Meta App verify token |
| `META_WEBHOOK_APP_SECRET` | — | HMAC validation secret |
| `META_SYSTEM_USER_TOKEN` | — | Bearer pra Meta Graph API |
| `META_PHONE_NUMBER_ID` | — | WABA phone id |
| `META_GRAPH_API_VERSION` | `v21.0` | Meta API version |
| `META_SELF_CALLBACK_URL` | — | Gateway public URL/meta/dispatch |
| `META_DISPATCH_SECRET` | — | Shared secret callback auth |
| `META_FLOW_REGISTRY` | — | `flow1:svc1;flow2:svc2` |
| `META_FLOW_DEFAULT_SERVICE` | — | Fallback service_name |

## Tests

- **78 tests novos** (vs 19 do POC original):
  - `meta_webhook_test.go` (handlers): 18 (HMAC, dedup, parse-por-tipo, anti-loop, Flow registry, status persist)
  - `meta_dispatch_test.go` (handlers): 16 (auth, dispatch routing, upload, redis errors)
  - `meta_envelope_test.go` (handlers): 11 (envelope extract, registry resolve)
  - `meta_graph_service_test.go` (services): 14 (todos métodos Send + Upload + Download)
- `go build ./... && go test ./internal/...` green em todos pacotes

## Codex review

8 rounds, ~22 P1/P2 corrigidas progressivamente. Principais:
- R1: silent drop quando handler "would enqueue here" → fail-loud 503
- R2: HMAC empty token aceita (fail-closed agora)
- R3: dispatch sem auth → header secret obrigatório
- R4: dispatch secret leaking → restrito ao SelfCallbackURL
- R5: `ErrKeyNotFound` sentinel pra discriminar miss esperado vs Redis down
- R6: TTL callback alvo 10min insuficiente pra worker 30min → ajustado pra max(TaskStatusTTL, 1h)
- R7: dispatch só fazia SendText → roteamento por tipo via envelope
- R8: base64 sem upload → UploadMedia wired; lock TTL alinhado com MessageTimeout; Flow diacritic normalization
- R9: multipart MIME type default rejeitado; lock renewal unconditional roubava lock → CAS Lua atômico

## Test plan

- [x] `go build ./... && go test ./internal/... -count=1` green
- [x] 78 unit tests cobrindo todos paths
- [x] Codex review uncommitted: 8 rounds, clean final
- [ ] Deploy staging com `META_DIRECT_ENABLED=true` em Meta App **separado**
- [ ] Smoke E2E texto inbound→Engine→outbound
- [ ] Smoke E2E media (áudio gerado, imagem por URL, localização)
- [ ] Smoke WhatsApp Flow submit
- [ ] Comparar latência p50/p95 com Mule baseline
- [ ] Stakeholder review antes do cutover Callback URL

## Riscos

- **Feature flag default OFF** — zero impacto produção
- Cutover do Callback URL Meta é **big-bang** (Meta callback model é 1 URL por App, sem percentage canary) — exige test number em **Meta App separado** antes
- MC proactive Journeys NÃO migradas (out of scope; decisão Prefeitura sobre alternativa)

🤖 Generated with [Claude Code](https://claude.com/claude-code)