### PR TITLE
fix(config): bind GOVBR env vars no viper

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -573,6 +573,14 @@ func bindEnvironmentVariables() {
 	_ = viper.BindEnv("CALLBACK_ALLOWED_DOMAIN")
 	_ = viper.BindEnv("CALLBACK_AUTH_TOKEN")
 
+	_ = viper.BindEnv("GOVBR_CLIENT_ID")
+	_ = viper.BindEnv("GOVBR_CLIENT_SECRET")
+	_ = viper.BindEnv("GOVBR_REDIRECT_URI")
+	_ = viper.BindEnv("GOVBR_AUTH_URL")
+	_ = viper.BindEnv("GOVBR_TOKEN_URL")
+	_ = viper.BindEnv("GOVBR_SCOPE")
+	_ = viper.BindEnv("GOVBR_AUTH_STATE_TTL")
+
 	// Data Relay
 	_ = viper.BindEnv("DATA_RELAY_ENABLED")
 	_ = viper.BindEnv("DATA_RELAY_BASE_URL")


### PR DESCRIPTION
## Problema

As vars `GOVBR_*` estavam definidas na struct com `mapstructure` mas não eram registradas no `bindEnvironmentVariables()`. O viper não as carregava mesmo estando no environment, então `client_id`, `redirect_uri`, `scope` chegavam vazios no handler.

## Fix

Adicionado `BindEnv` explícito para todas as 7 vars:

```
GOVBR_CLIENT_ID
GOVBR_CLIENT_SECRET
GOVBR_REDIRECT_URI
GOVBR_AUTH_URL
GOVBR_TOKEN_URL
GOVBR_SCOPE
GOVBR_AUTH_STATE_TTL
```

## Relacionado

- Completa #35