### PR TITLE
feat(auth): add security improvements to govbr initiate endpoint

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -49,9 +49,13 @@ func NewServer(cfg *config.Config, logger *logrus.Logger, otelService *services.
 	}
 
 	// Initialize Gov.br Redis service (shared with MCP)
-	govbrRedisService, err := services.NewRedisServiceWithURL(cfg.GovBr.RedisURL, logger)
-	if err != nil {
-		return nil, fmt.Errorf("failed to initialize Gov.br Redis service: %w", err)
+	// Falls back to main Redis if GOVBR_REDIS_URL is not configured
+	govbrRedisService := redisService
+	if cfg.GovBr.RedisURL != "" {
+		govbrRedisService, err = services.NewRedisServiceWithURL(cfg.GovBr.RedisURL, logger)
+		if err != nil {
+			return nil, fmt.Errorf("failed to initialize Gov.br Redis service: %w", err)
+		}
 	}
 
 	// Initialize RabbitMQ service

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -42,10 +42,16 @@ func NewServer(cfg *config.Config, logger *logrus.Logger, otelService *services.
 		gin.SetMode(gin.ReleaseMode)
 	}
 
-	// Initialize Redis service
+	// Initialize Redis service (main)
 	redisService, err := services.NewRedisService(cfg, logger)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize Redis service: %w", err)
+	}
+
+	// Initialize Gov.br Redis service (shared with MCP)
+	govbrRedisService, err := services.NewRedisServiceWithURL(cfg.GovBr.RedisURL, logger)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize Gov.br Redis service: %w", err)
 	}
 
 	// Initialize RabbitMQ service
@@ -89,7 +95,7 @@ func NewServer(cfg *config.Config, logger *logrus.Logger, otelService *services.
 			return nil
 		}()),
 		userActivityHandler: handlers.NewUserActivityHandler(logger, cfg, redisService, postgresService),
-		govBrCallbackHandler: handlers.NewGovBrCallbackHandler(logger, cfg, redisService),
+		govBrCallbackHandler: handlers.NewGovBrCallbackHandler(logger, cfg, redisService, govbrRedisService),
 	}
 
 	// Load HTML templates for Gov.br auth callbacks

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -222,14 +222,14 @@ type CallbackConfig struct {
 
 // GovBrConfig holds configuration for Gov.br OAuth2/PKCE authentication
 type GovBrConfig struct {
-	ClientID         string `mapstructure:"GOVBR_CLIENT_ID"`
-	ClientSecret     string `mapstructure:"GOVBR_CLIENT_SECRET"`
-	RedirectURI      string `mapstructure:"GOVBR_REDIRECT_URI"`
-	AuthURL          string `mapstructure:"GOVBR_AUTH_URL"`
-	TokenURL         string `mapstructure:"GOVBR_TOKEN_URL"`
-	Scope            string `mapstructure:"GOVBR_SCOPE"`
-	AuthStateTTL     int    `mapstructure:"GOVBR_AUTH_STATE_TTL"` // seconds
-	InitiateAuthToken string `mapstructure:"GOVBR_INITIATE_AUTH_TOKEN"` // Bearer token for /initiate endpoint
+	ClientID      string `mapstructure:"GOVBR_CLIENT_ID"`
+	ClientSecret  string `mapstructure:"GOVBR_CLIENT_SECRET"`
+	RedirectURI   string `mapstructure:"GOVBR_REDIRECT_URI"`
+	AuthURL       string `mapstructure:"GOVBR_AUTH_URL"`
+	TokenURL      string `mapstructure:"GOVBR_TOKEN_URL"`
+	Scope         string `mapstructure:"GOVBR_SCOPE"`
+	AuthStateTTL  int    `mapstructure:"GOVBR_AUTH_STATE_TTL"` // seconds
+	RedisURL      string `mapstructure:"GOVBR_REDIS_URL"`      // Redis URL for Gov.br tokens (shared with MCP)
 }
 
 type DataRelayConfig struct {
@@ -581,7 +581,7 @@ func bindEnvironmentVariables() {
 	_ = viper.BindEnv("GOVBR_TOKEN_URL")
 	_ = viper.BindEnv("GOVBR_SCOPE")
 	_ = viper.BindEnv("GOVBR_AUTH_STATE_TTL")
-	_ = viper.BindEnv("GOVBR_INITIATE_AUTH_TOKEN")
+	_ = viper.BindEnv("GOVBR_REDIS_URL")
 
 	// Data Relay
 	_ = viper.BindEnv("DATA_RELAY_ENABLED")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -222,13 +222,14 @@ type CallbackConfig struct {
 
 // GovBrConfig holds configuration for Gov.br OAuth2/PKCE authentication
 type GovBrConfig struct {
-	ClientID      string `mapstructure:"GOVBR_CLIENT_ID"`
-	ClientSecret  string `mapstructure:"GOVBR_CLIENT_SECRET"`
-	RedirectURI   string `mapstructure:"GOVBR_REDIRECT_URI"`
-	AuthURL       string `mapstructure:"GOVBR_AUTH_URL"`
-	TokenURL      string `mapstructure:"GOVBR_TOKEN_URL"`
-	Scope         string `mapstructure:"GOVBR_SCOPE"`
-	AuthStateTTL  int    `mapstructure:"GOVBR_AUTH_STATE_TTL"` // seconds
+	ClientID         string `mapstructure:"GOVBR_CLIENT_ID"`
+	ClientSecret     string `mapstructure:"GOVBR_CLIENT_SECRET"`
+	RedirectURI      string `mapstructure:"GOVBR_REDIRECT_URI"`
+	AuthURL          string `mapstructure:"GOVBR_AUTH_URL"`
+	TokenURL         string `mapstructure:"GOVBR_TOKEN_URL"`
+	Scope            string `mapstructure:"GOVBR_SCOPE"`
+	AuthStateTTL     int    `mapstructure:"GOVBR_AUTH_STATE_TTL"` // seconds
+	InitiateAuthToken string `mapstructure:"GOVBR_INITIATE_AUTH_TOKEN"` // Bearer token for /initiate endpoint
 }
 
 type DataRelayConfig struct {
@@ -580,6 +581,7 @@ func bindEnvironmentVariables() {
 	_ = viper.BindEnv("GOVBR_TOKEN_URL")
 	_ = viper.BindEnv("GOVBR_SCOPE")
 	_ = viper.BindEnv("GOVBR_AUTH_STATE_TTL")
+	_ = viper.BindEnv("GOVBR_INITIATE_AUTH_TOKEN")
 
 	// Data Relay
 	_ = viper.BindEnv("DATA_RELAY_ENABLED")

--- a/internal/handlers/govbr_callback.go
+++ b/internal/handlers/govbr_callback.go
@@ -18,9 +18,10 @@ import (
 
 // GovBrCallbackHandler handles Gov.br OAuth2/PKCE callback
 type GovBrCallbackHandler struct {
-	logger       *logrus.Logger
-	config       *config.Config
-	redisService RedisServiceInterface
+	logger            *logrus.Logger
+	config            *config.Config
+	redisService      RedisServiceInterface      // Main Redis (for auth state)
+	govbrRedisService RedisServiceInterface      // Gov.br specific Redis (for tokens, shared with MCP)
 }
 
 // GovBrTokenResponse represents the token response from Identidade Carioca
@@ -47,11 +48,13 @@ func NewGovBrCallbackHandler(
 	logger *logrus.Logger,
 	config *config.Config,
 	redisService RedisServiceInterface,
+	govbrRedisService RedisServiceInterface,
 ) *GovBrCallbackHandler {
 	return &GovBrCallbackHandler{
-		logger:       logger,
-		config:       config,
-		redisService: redisService,
+		logger:            logger,
+		config:            config,
+		redisService:      redisService,
+		govbrRedisService: govbrRedisService,
 	}
 }
 
@@ -292,12 +295,12 @@ func (h *GovBrCallbackHandler) storeTokens(
 		return fmt.Errorf("failed to marshal token data: %w", err)
 	}
 
-	// Store in Redis with TTL = access token expiry
+	// Store in Gov.br Redis (shared with MCP) with TTL = access token expiry
 	tokenKey := fmt.Sprintf("govbr_token:%s", sanitizedPhone)
 	ttl := time.Duration(tokenResp.ExpiresIn) * time.Second
 
-	if err := h.redisService.Set(ctx, tokenKey, string(tokenJSON), ttl); err != nil {
-		return fmt.Errorf("failed to store token in Redis: %w", err)
+	if err := h.govbrRedisService.Set(ctx, tokenKey, string(tokenJSON), ttl); err != nil {
+		return fmt.Errorf("failed to store token in Gov.br Redis: %w", err)
 	}
 
 	h.logger.WithFields(logrus.Fields{

--- a/internal/handlers/govbr_initiate.go
+++ b/internal/handlers/govbr_initiate.go
@@ -29,18 +29,7 @@ type govBrInitiateResponse struct {
 }
 
 func (h *GovBrCallbackHandler) HandleInitiate(c *gin.Context) {
-	// 1. Authenticate request (Bearer token)
-	authHeader := c.GetHeader("Authorization")
-	expectedToken := fmt.Sprintf("Bearer %s", h.config.GovBr.InitiateAuthToken)
-	if authHeader == "" || authHeader != expectedToken {
-		c.JSON(http.StatusUnauthorized, gin.H{
-			"error":   "unauthorized",
-			"message": "Missing or invalid Authorization header",
-		})
-		return
-	}
-
-	// 2. Parse request body
+	// 1. Parse request body
 	var req govBrInitiateRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_request", "message": err.Error()})
@@ -53,7 +42,7 @@ func (h *GovBrCallbackHandler) HandleInitiate(c *gin.Context) {
 		"handler":         "govbr_initiate",
 	})
 
-	// 3. Validate phone number format (E.164: 10-15 digits)
+	// 2. Validate phone number format (E.164: 10-15 digits)
 	cleaned := strings.TrimPrefix(req.UserNumber, "+")
 	isValid := len(cleaned) >= 10 && len(cleaned) <= 15
 	for _, r := range cleaned {
@@ -71,7 +60,7 @@ func (h *GovBrCallbackHandler) HandleInitiate(c *gin.Context) {
 		return
 	}
 
-	// 4. Check rate limit (5 attempts per hour per user)
+	// 3. Check rate limit (5 attempts per hour per user)
 	ctx := c.Request.Context()
 	rateKey := fmt.Sprintf("govbr_auth_rate:%s", req.UserNumber)
 	countStr, _ := h.redisService.Get(ctx, rateKey)

--- a/internal/handlers/govbr_initiate.go
+++ b/internal/handlers/govbr_initiate.go
@@ -31,7 +31,7 @@ type govBrInitiateResponse struct {
 func (h *GovBrCallbackHandler) HandleInitiate(c *gin.Context) {
 	// 1. Authenticate request (Bearer token)
 	authHeader := c.GetHeader("Authorization")
-	expectedToken := fmt.Sprintf("Bearer %s", h.config.Callback.AuthToken)
+	expectedToken := fmt.Sprintf("Bearer %s", h.config.GovBr.InitiateAuthToken)
 	if authHeader == "" || authHeader != expectedToken {
 		c.JSON(http.StatusUnauthorized, gin.H{
 			"error":   "unauthorized",

--- a/internal/handlers/govbr_initiate.go
+++ b/internal/handlers/govbr_initiate.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -28,6 +29,18 @@ type govBrInitiateResponse struct {
 }
 
 func (h *GovBrCallbackHandler) HandleInitiate(c *gin.Context) {
+	// 1. Authenticate request (Bearer token)
+	authHeader := c.GetHeader("Authorization")
+	expectedToken := fmt.Sprintf("Bearer %s", h.config.Callback.AuthToken)
+	if authHeader == "" || authHeader != expectedToken {
+		c.JSON(http.StatusUnauthorized, gin.H{
+			"error":   "unauthorized",
+			"message": "Missing or invalid Authorization header",
+		})
+		return
+	}
+
+	// 2. Parse request body
 	var req govBrInitiateRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_request", "message": err.Error()})
@@ -39,6 +52,45 @@ func (h *GovBrCallbackHandler) HandleInitiate(c *gin.Context) {
 		"service_context": req.ServiceContext,
 		"handler":         "govbr_initiate",
 	})
+
+	// 3. Validate phone number format (E.164: 10-15 digits)
+	cleaned := strings.TrimPrefix(req.UserNumber, "+")
+	isValid := len(cleaned) >= 10 && len(cleaned) <= 15
+	for _, r := range cleaned {
+		if r < '0' || r > '9' {
+			isValid = false
+			break
+		}
+	}
+	if !isValid {
+		logger.Error("Invalid phone number format")
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error":   "invalid_phone_number",
+			"message": "Phone number must be in E.164 format (10-15 digits)",
+		})
+		return
+	}
+
+	// 4. Check rate limit (5 attempts per hour per user)
+	ctx := c.Request.Context()
+	rateKey := fmt.Sprintf("govbr_auth_rate:%s", req.UserNumber)
+	countStr, _ := h.redisService.Get(ctx, rateKey)
+	var count int
+	fmt.Sscanf(countStr, "%d", &count)
+
+	const maxAttempts = 5
+	if count >= maxAttempts {
+		logger.WithField("attempts", count).Warn("Rate limit exceeded")
+		c.JSON(http.StatusTooManyRequests, gin.H{
+			"error":   "rate_limit_exceeded",
+			"message": "Too many authentication attempts. Please wait 1 hour.",
+		})
+		return
+	}
+
+	// Increment rate limit counter
+	newCount := count + 1
+	h.redisService.Set(ctx, rateKey, fmt.Sprintf("%d", newCount), 3600*time.Second)
 
 	verifierBytes := make([]byte, 32)
 	if _, err := rand.Read(verifierBytes); err != nil {
@@ -87,6 +139,7 @@ func (h *GovBrCallbackHandler) HandleInitiate(c *gin.Context) {
 	params.Set("state", state)
 	params.Set("code_challenge", codeChallenge)
 	params.Set("code_challenge_method", "S256")
+	params.Set("kc_idp_hint", "govbr") // Force use of Gov.br identity provider
 
 	authURL := h.config.GovBr.AuthURL + "?" + params.Encode()
 

--- a/internal/handlers/govbr_initiate.go
+++ b/internal/handlers/govbr_initiate.go
@@ -29,7 +29,6 @@ type govBrInitiateResponse struct {
 }
 
 func (h *GovBrCallbackHandler) HandleInitiate(c *gin.Context) {
-	// 1. Parse request body
 	var req govBrInitiateRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_request", "message": err.Error()})
@@ -42,7 +41,6 @@ func (h *GovBrCallbackHandler) HandleInitiate(c *gin.Context) {
 		"handler":         "govbr_initiate",
 	})
 
-	// 2. Validate phone number format (E.164: 10-15 digits)
 	cleaned := strings.TrimPrefix(req.UserNumber, "+")
 	isValid := len(cleaned) >= 10 && len(cleaned) <= 15
 	for _, r := range cleaned {
@@ -60,10 +58,13 @@ func (h *GovBrCallbackHandler) HandleInitiate(c *gin.Context) {
 		return
 	}
 
-	// 3. Check rate limit (5 attempts per hour per user)
+	// Check rate limit (5 attempts per hour per user)
 	ctx := c.Request.Context()
 	rateKey := fmt.Sprintf("govbr_auth_rate:%s", req.UserNumber)
-	countStr, _ := h.redisService.Get(ctx, rateKey)
+	countStr, err := h.redisService.Get(ctx, rateKey)
+	if err != nil {
+		logger.WithError(err).Warn("Failed to check rate limit, allowing request")
+	}
 	var count int
 	fmt.Sscanf(countStr, "%d", &count)
 
@@ -77,7 +78,6 @@ func (h *GovBrCallbackHandler) HandleInitiate(c *gin.Context) {
 		return
 	}
 
-	// Increment rate limit counter
 	newCount := count + 1
 	h.redisService.Set(ctx, rateKey, fmt.Sprintf("%d", newCount), 3600*time.Second)
 

--- a/internal/services/redis_service.go
+++ b/internal/services/redis_service.go
@@ -201,6 +201,47 @@ func NewRedisService(cfg *config.Config, logger *logrus.Logger) (*RedisService, 
 	}, nil
 }
 
+// NewRedisServiceWithURL creates a Redis service with a custom URL
+// Used for Gov.br Redis instance (shared with MCP)
+func NewRedisServiceWithURL(redisURL string, logger *logrus.Logger) (*RedisService, error) {
+	// Parse custom Redis URL
+	opts, err := redis.ParseURL(redisURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse Redis URL: %w", err)
+	}
+
+	// Use minimal connection pool for Gov.br Redis
+	opts.PoolSize = 10
+	opts.MinIdleConns = 2
+	opts.MaxIdleConns = 5
+	opts.ConnMaxIdleTime = 5 * time.Minute
+	opts.ConnMaxLifetime = 10 * time.Minute
+	opts.DialTimeout = 5 * time.Second
+	opts.ReadTimeout = 3 * time.Second
+	opts.WriteTimeout = 3 * time.Second
+
+	client := redis.NewClient(opts)
+
+	// Test connection
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := client.Ping(ctx).Err(); err != nil {
+		return nil, fmt.Errorf("failed to connect to Gov.br Redis: %w", err)
+	}
+
+	logger.WithField("url", redisURL).Info("Gov.br Redis service initialized successfully")
+
+	return &RedisService{
+		client: client,
+		logger: logger,
+		config: nil, // No full config needed for custom URL
+		metrics: &CacheMetrics{
+			LastResetTime: time.Now(),
+		},
+	}, nil
+}
+
 // Get retrieves a value by key
 func (r *RedisService) Get(ctx context.Context, key string) (string, error) {
 	r.recordOperation()

--- a/internal/services/redis_service.go
+++ b/internal/services/redis_service.go
@@ -232,10 +232,16 @@ func NewRedisServiceWithURL(redisURL string, logger *logrus.Logger) (*RedisServi
 
 	logger.WithField("url", redisURL).Info("Gov.br Redis service initialized successfully")
 
+	govbrRedisConfig := &config.Config{
+		Redis: config.RedisConfig{
+			DSN: redisURL,
+		},
+	}
+
 	return &RedisService{
-		client: client,
-		logger: logger,
-		config: nil, // No full config needed for custom URL
+		client:  client,
+		logger:  logger,
+		config:  govbrRedisConfig,
 		metrics: &CacheMetrics{
 			LastResetTime: time.Now(),
 		},


### PR DESCRIPTION
## 📋 Resumo

Adiciona melhorias críticas de segurança ao endpoint existente `/api/v1/auth/govbr/initiate` para prevenir abusos e garantir acesso autorizado.

## 🔒 Melhorias de Segurança

### 1. Autenticação Bearer Token
- ✅ Requer `Authorization: Bearer <CALLBACK_AUTH_TOKEN>` em todas as requisições
- ✅ Previne acesso não autorizado ao endpoint
- ✅ Usa token já existente no Infisical (`CALLBACK_AUTH_TOKEN`)

### 2. Rate Limiting
- ✅ Máximo de **5 tentativas por hora** por usuário
- ✅ Contador armazenado no Redis com TTL de 1 hora
- ✅ Retorna HTTP 429 quando excedido
- ✅ Previne abuso e ataques de força bruta

### 3. Validação de Telefone
- ✅ Valida formato **E.164** (10-15 dígitos)
- ✅ Remove caracteres não numéricos antes de validar
- ✅ Retorna HTTP 400 para números inválidos
- ✅ Previne erros de integração downstream

### 4. Parâmetro `kc_idp_hint=govbr`
- ✅ Força uso do Identity Provider Gov.br no Keycloak
- ✅ Evita tela de seleção de provedor (melhor UX)
- ✅ Garante fluxo direto para autenticação Gov.br