### PR TITLE
feat(govbr): melhora UX das páginas de callback de autenticação

### DIFF
--- a/internal/handlers/govbr_callback.go
+++ b/internal/handlers/govbr_callback.go
@@ -89,9 +89,15 @@ func (h *GovBrCallbackHandler) HandleCallback(c *gin.Context) {
 			"error_description": errorDescription,
 		}).Warn("Error returned by OAuth provider")
 
+		// Fallback for empty error description
+		if errorDescription == "" {
+			errorDescription = "Erro durante o processo de autenticação"
+		}
+
 		c.HTML(http.StatusOK, "govbr_auth_error.html", gin.H{
 			"error":       errorParam,
 			"description": errorDescription,
+			"ttl_minutes": h.config.GovBr.AuthStateTTL / 60,
 		})
 		return
 	}
@@ -102,6 +108,7 @@ func (h *GovBrCallbackHandler) HandleCallback(c *gin.Context) {
 		c.HTML(http.StatusBadRequest, "govbr_auth_error.html", gin.H{
 			"error":       "invalid_request",
 			"description": "Parâmetros de callback inválidos",
+			"ttl_minutes": h.config.GovBr.AuthStateTTL / 60,
 		})
 		return
 	}
@@ -115,6 +122,7 @@ func (h *GovBrCallbackHandler) HandleCallback(c *gin.Context) {
 			"error": "expired_request",
 			"description": "Sessão de autenticação expirada. " +
 				"Por favor, retorne ao WhatsApp e inicie o processo novamente.",
+			"ttl_minutes": h.config.GovBr.AuthStateTTL / 60,
 		})
 		return
 	}
@@ -125,6 +133,7 @@ func (h *GovBrCallbackHandler) HandleCallback(c *gin.Context) {
 		c.HTML(http.StatusInternalServerError, "govbr_auth_error.html", gin.H{
 			"error":       "internal_error",
 			"description": "Erro ao processar estado de autenticação",
+			"ttl_minutes": h.config.GovBr.AuthStateTTL / 60,
 		})
 		return
 	}
@@ -135,6 +144,7 @@ func (h *GovBrCallbackHandler) HandleCallback(c *gin.Context) {
 		c.HTML(http.StatusBadRequest, "govbr_auth_error.html", gin.H{
 			"error":       "invalid_state",
 			"description": "Estado de autenticação inválido",
+			"ttl_minutes": h.config.GovBr.AuthStateTTL / 60,
 		})
 		return
 	}
@@ -151,6 +161,7 @@ func (h *GovBrCallbackHandler) HandleCallback(c *gin.Context) {
 		c.HTML(http.StatusInternalServerError, "govbr_auth_error.html", gin.H{
 			"error":       "token_exchange_failed",
 			"description": "Erro ao obter token de acesso. Tente novamente.",
+			"ttl_minutes": h.config.GovBr.AuthStateTTL / 60,
 		})
 		return
 	}
@@ -161,6 +172,7 @@ func (h *GovBrCallbackHandler) HandleCallback(c *gin.Context) {
 		c.HTML(http.StatusInternalServerError, "govbr_auth_error.html", gin.H{
 			"error":       "storage_error",
 			"description": "Erro ao armazenar credenciais",
+			"ttl_minutes": h.config.GovBr.AuthStateTTL / 60,
 		})
 		return
 	}
@@ -178,9 +190,14 @@ func (h *GovBrCallbackHandler) HandleCallback(c *gin.Context) {
 	// Implementation depends on WhatsApp messaging service integration
 
 	// 8. Render success page
+	serviceContext := authState.ServiceContext
+	if serviceContext == "" {
+		serviceContext = "Serviço da Prefeitura"
+	}
+
 	c.HTML(http.StatusOK, "govbr_auth_success.html", gin.H{
 		"user_number": maskPhoneNumber(authState.UserNumber),
-		"service":     authState.ServiceContext,
+		"service":     serviceContext,
 	})
 }
 

--- a/templates/govbr_auth_error.html
+++ b/templates/govbr_auth_error.html
@@ -3,7 +3,12 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Erro na autenticação gov.br. Retorne ao WhatsApp e tente novamente.">
+    <meta property="og:title" content="Erro na Autenticação">
+    <meta property="og:description" content="Erro na autenticação gov.br">
+    <meta property="og:type" content="website">
     <title>Erro na Autenticação - Prefeitura do Rio</title>
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🏛️</text></svg>">
     <style>
         * {
             margin: 0;
@@ -18,7 +23,7 @@
             align-items: center;
             min-height: 100vh;
             margin: 0;
-            background: linear-gradient(135deg, #f093fb 0%, #f5576c 100%);
+            background: linear-gradient(135deg, #13335a 0%, #0a1f38 100%);
             color: #333;
         }
 
@@ -86,32 +91,6 @@
             font-size: 16px;
         }
 
-        .error-details {
-            margin: 24px 0;
-            padding: 16px;
-            background: #fef2f2;
-            border-radius: 12px;
-            border-left: 4px solid #ef4444;
-        }
-
-        .error-details strong {
-            display: block;
-            color: #991b1b;
-            margin-bottom: 8px;
-            font-size: 14px;
-        }
-
-        .error-code {
-            font-family: 'Courier New', monospace;
-            font-size: 13px;
-            color: #7f1d1d;
-            background: #fee2e2;
-            padding: 8px 12px;
-            border-radius: 6px;
-            display: inline-block;
-            margin-top: 8px;
-        }
-
         .error-description {
             color: #991b1b;
             font-size: 15px;
@@ -126,14 +105,6 @@
             color: #78350f;
             font-size: 15px;
             font-weight: 500;
-        }
-
-        .whatsapp-icon {
-            display: inline-block;
-            width: 20px;
-            height: 20px;
-            vertical-align: middle;
-            margin-right: 8px;
         }
 
         .help-section {
@@ -189,22 +160,15 @@
 
         <p class="error-description">{{ .description }}</p>
 
-        <div class="error-details">
-            <strong>Detalhes do erro:</strong>
-            <div class="error-code">{{ .error }}</div>
-        </div>
-
         <div class="action-message">
-            <svg class="whatsapp-icon" viewBox="0 0 24 24" fill="#78350f" xmlns="http://www.w3.org/2000/svg">
-                <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413Z"/>
-            </svg>
+            <span style="font-size: 20px; margin-right: 8px;">💬</span>
             <strong>Retorne ao WhatsApp</strong> e tente novamente
         </div>
 
         <div class="help-section">
             <strong>💡 O que pode ter acontecido?</strong>
             <ul>
-                <li>Link de autenticação expirado (válido por 5 minutos)</li>
+                <li>Link de autenticação expirado (válido por {{ .ttl_minutes }} minutos)</li>
                 <li>Erro ao se conectar com gov.br</li>
                 <li>Sessão cancelada pelo usuário</li>
                 <li>Erro temporário no servidor</li>
@@ -212,8 +176,7 @@
         </div>
 
         <div class="footer">
-            Prefeitura da Cidade do Rio de Janeiro<br>
-            Se o problema persistir, entre em contato com o suporte
+            Prefeitura da Cidade do Rio de Janeiro
         </div>
     </div>
 </body>

--- a/templates/govbr_auth_success.html
+++ b/templates/govbr_auth_success.html
@@ -3,7 +3,12 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Autenticação gov.br realizada com sucesso. Retorne ao WhatsApp para continuar utilizando os serviços da Prefeitura do Rio de Janeiro.">
+    <meta property="og:title" content="Autenticação Concluída">
+    <meta property="og:description" content="Autenticação gov.br realizada com sucesso">
+    <meta property="og:type" content="website">
     <title>Autenticação Concluída - Prefeitura do Rio</title>
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🏛️</text></svg>">
     <style>
         * {
             margin: 0;
@@ -18,7 +23,7 @@
             align-items: center;
             min-height: 100vh;
             margin: 0;
-            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            background: linear-gradient(135deg, #13335a 0%, #0a1f38 100%);
             color: #333;
         }
 
@@ -126,14 +131,6 @@
             font-weight: 500;
         }
 
-        .whatsapp-icon {
-            display: inline-block;
-            width: 20px;
-            height: 20px;
-            vertical-align: middle;
-            margin-right: 8px;
-        }
-
         .footer {
             margin-top: 24px;
             padding-top: 24px;
@@ -169,9 +166,7 @@
         </div>
 
         <p>
-            <svg class="whatsapp-icon" viewBox="0 0 24 24" fill="#25D366" xmlns="http://www.w3.org/2000/svg">
-                <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413Z"/>
-            </svg>
+            <span style="font-size: 20px; margin-right: 8px;">💬</span>
             <strong>Retorne ao WhatsApp</strong> para continuar utilizando os serviços.
         </p>
 


### PR DESCRIPTION
## Mudanças

- Substitui SVG do WhatsApp por emoji 💬 (corrige renderização gigante)
- Aplica azul oficial Prefeitura Rio (#13335a)
- Remove código técnico de erro da página (mantém nos logs)
- Adiciona favicon 🏛️ e meta tags
- Adiciona fallbacks para campos vazios
- Torna TTL dinâmico na mensagem de expiração
- Remove menção a suporte inexistente