### PR TITLE
fix(govbr): não logar callback_url (telefone) — usa message_id (LGPD)

### DIFF
--- a/internal/handlers/message.go
+++ b/internal/handlers/message.go
@@ -246,7 +246,7 @@ func (h *MessageHandler) HandleUserWebhook(c *gin.Context) {
 		if err := h.redisService.StoreCallbackURL(ctxTimeout, messageID, *req.CallbackURL, h.config.Redis.TaskStatusTTL); err != nil {
 			logger.WithError(err).Warn("Failed to store callback URL, continuing with processing")
 		} else {
-			logger.WithField("callback_url", *req.CallbackURL).Debug("Callback URL stored for message")
+			logger.WithField("message_id", messageID).Debug("Callback URL stored for message")
 		}
 	}
 

--- a/internal/handlers/message.go
+++ b/internal/handlers/message.go
@@ -140,7 +140,10 @@ func (h *MessageHandler) HandleUserWebhook(c *gin.Context) {
 	// Validate callback URL if provided
 	if req.CallbackURL != nil && *req.CallbackURL != "" {
 		if err := validateCallbackURL(*req.CallbackURL); err != nil {
-			h.logger.WithError(err).WithField("callback_url", *req.CallbackURL).Error("Invalid callback URL")
+			// Não logar o callback_url cru: ele carrega o telefone do cidadão
+			// (LGPD). O erro de validação já descreve o motivo (scheme/host
+			// inválido) sem ecoar a URL.
+			h.logger.WithError(err).Error("Invalid callback URL")
 			c.JSON(http.StatusBadRequest, gin.H{
 				"error":   "Invalid callback URL",
 				"message": err.Error(),
@@ -629,7 +632,10 @@ func validateCallbackURL(callbackURL string) error {
 	// Parse URL
 	parsedURL, err := url.Parse(callbackURL)
 	if err != nil {
-		return fmt.Errorf("invalid callback URL format: %w", err)
+		// Não embrulhar o erro do url.Parse com %w: o .Error() dele ecoa a
+		// URL crua (que carrega o telefone do cidadão — LGPD), e esse erro
+		// vai tanto pro log quanto pro corpo da resposta. Motivo sanitizado.
+		return fmt.Errorf("invalid callback URL format")
 	}
 
 	// Validate scheme - only allow http/https

--- a/internal/handlers/validate_callback_url_test.go
+++ b/internal/handlers/validate_callback_url_test.go
@@ -1,0 +1,29 @@
+package handlers
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestValidateCallbackURLDoesNotLeakRawURL trava o gap LGPD do #42: quando a URL
+// é malformada e falha no url.Parse, o erro retornado NÃO pode ecoar a URL crua
+// (que carrega o telefone do cidadão), porque esse erro vai tanto para o log
+// quanto para o corpo da resposta HTTP.
+func TestValidateCallbackURLDoesNotLeakRawURL(t *testing.T) {
+	const phone = "5521999998888"
+	const host = "cb.example.com"
+	// Um caractere de controle (DEL, 0x7f) faz o url.Parse falhar; o erro do Go
+	// ecoaria a string de entrada inteira se fosse embrulhado com %w.
+	malformed := "https://" + host + "/notify?phone=" + phone + "\x7f"
+
+	err := validateCallbackURL(malformed)
+	if err == nil {
+		t.Fatal("esperava que validateCallbackURL rejeitasse a URL malformada")
+	}
+	if strings.Contains(err.Error(), phone) {
+		t.Fatalf("erro vaza o telefone da URL crua: %q", err.Error())
+	}
+	if strings.Contains(err.Error(), host) {
+		t.Fatalf("erro vaza o host da URL crua: %q", err.Error())
+	}
+}

--- a/internal/handlers/workers/message_handlers.go
+++ b/internal/handlers/workers/message_handlers.go
@@ -1285,10 +1285,12 @@ func classifyTranscriptionError(err error) string {
 
 // executeCallback handles the callback execution asynchronously
 func executeCallback(ctx context.Context, deps *MessageHandlerDependencies, messageID string, userNumber string, callbackURL string, response string, logger *logrus.Entry) {
+	// Não logar o callback_url: ele carrega o telefone do cidadão no path/query
+	// (LGPD). message_id é a chave Redis pra recuperar a URL out-of-band sem
+	// deixá-la no stream de log.
 	callbackLogger := logger.WithFields(logrus.Fields{
-		"callback_url": callbackURL,
-		"message_id":   messageID,
-		"user_number":  userNumber,
+		"message_id":  messageID,
+		"user_number": userNumber,
 	})
 
 	callbackLogger.Info("Executing callback for completed task")

--- a/internal/services/callback_service.go
+++ b/internal/services/callback_service.go
@@ -7,6 +7,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -59,7 +60,9 @@ func (s *CallbackService) ValidateCallbackURL(callbackURL string) error {
 	// Parse URL
 	parsedURL, err := url.Parse(callbackURL)
 	if err != nil {
-		return fmt.Errorf("invalid callback URL format: %w", err)
+		// Não embrulhar o erro do url.Parse com %w: o .Error() dele ecoa a URL
+		// crua (que carrega o telefone do cidadão — LGPD). Motivo sanitizado.
+		return fmt.Errorf("invalid callback URL format")
 	}
 
 	// Require HTTPS if configured
@@ -90,18 +93,20 @@ func (s *CallbackService) ValidateCallbackURL(callbackURL string) error {
 
 // ExecuteCallback sends a POST request to the callback URL with retry logic
 func (s *CallbackService) ExecuteCallback(ctx context.Context, callbackURL string, payload models.CallbackPayload, userNumber string) error {
+	// Não logar o callback_url (telefone do cidadão no path/query — LGPD);
+	// message_id correlaciona out-of-band.
 	logger := s.logger.WithFields(logrus.Fields{
-		"callback_url": callbackURL,
-		"message_id":   payload.MessageID,
-		"status":       payload.Status,
+		"message_id": payload.MessageID,
+		"status":     payload.Status,
 	})
 
 	// Create span for callback execution
 	var span trace.Span
 	if s.tracer != nil {
+		// callback.url omitido do span de propósito: ele vaza o telefone do
+		// cidadão pro backend de tracing (LGPD). message.id basta pra correlação.
 		ctx, span = s.tracer.Start(ctx, "execute_callback",
 			trace.WithAttributes(
-				attribute.String("callback.url", callbackURL),
 				attribute.String("message.id", payload.MessageID),
 				attribute.String("message.status", payload.Status),
 			),
@@ -173,12 +178,25 @@ func (s *CallbackService) ExecuteCallback(ctx context.Context, callbackURL strin
 	return fmt.Errorf("callback failed after %d attempts: %w", maxRetries+1, err)
 }
 
+// sanitizeURLError remove a URL crua de um *url.Error. O .Error() de um
+// *url.Error (devolvido por http.NewRequestWithContext e httpClient.Do) ecoa a
+// URL inteira — que carrega o telefone do cidadão no path/query (LGPD) — e esse
+// erro flui pra logs, span OTel (callback.error) e corpo do Data Relay. Devolver
+// a causa interna (.Err) preserva o motivo (timeout/DNS/conn recusada) sem a URL.
+func sanitizeURLError(err error) error {
+	var ue *url.Error
+	if errors.As(err, &ue) {
+		return ue.Err
+	}
+	return err
+}
+
 // sendCallbackRequest sends a single HTTP POST request to the callback URL
 func (s *CallbackService) sendCallbackRequest(ctx context.Context, callbackURL string, payloadBytes []byte, logger *logrus.Entry) error {
 	// Create request
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, callbackURL, bytes.NewReader(payloadBytes))
 	if err != nil {
-		return fmt.Errorf("failed to create request: %w", err)
+		return fmt.Errorf("failed to create request: %w", sanitizeURLError(err))
 	}
 
 	// Set headers
@@ -199,7 +217,7 @@ func (s *CallbackService) sendCallbackRequest(ctx context.Context, callbackURL s
 	// Send request
 	resp, err := s.httpClient.Do(req)
 	if err != nil {
-		return fmt.Errorf("request failed: %w", err)
+		return fmt.Errorf("request failed: %w", sanitizeURLError(err))
 	}
 	defer func() {
 		if closeErr := resp.Body.Close(); closeErr != nil {
@@ -287,8 +305,8 @@ func generateHMACSignature(payload []byte, secret string) string {
 // sendErrorInterceptor sends callback failure details to Data Relay
 // This runs asynchronously and doesn't block the callback flow
 func (s *CallbackService) sendErrorInterceptor(ctx context.Context, callbackURL string, payload models.CallbackPayload, userNumber string, callbackErr error) {
+	// Sem callback_url (telefone do cidadão — LGPD); message_id correlaciona.
 	logger := s.logger.WithFields(logrus.Fields{
-		"callback_url":   callbackURL,
 		"message_id":     payload.MessageID,
 		"user_number":    userNumber,
 		"callback_error": callbackErr.Error(),

--- a/internal/services/callback_service_test.go
+++ b/internal/services/callback_service_test.go
@@ -1,0 +1,48 @@
+package services
+
+import (
+	"errors"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// TestSanitizeURLErrorStripsRawURL trava o fix LGPD do caminho realista: quando
+// httpClient.Do / http.NewRequestWithContext falham (timeout, DNS, conn recusada
+// — a falha mais comum de callback), o *url.Error devolvido ecoa a URL inteira
+// no .Error(), e essa URL carrega o telefone do cidadão no path/query. Esse erro
+// flui pra logs, span OTel e corpo do Data Relay. sanitizeURLError tem de remover
+// a URL preservando o motivo.
+func TestSanitizeURLErrorStripsRawURL(t *testing.T) {
+	const phone = "5521999998888"
+	const host = "cb.example.com"
+	raw := "https://" + host + "/notify?phone=" + phone
+
+	ue := &url.Error{
+		Op:  "Post",
+		URL: raw,
+		Err: errors.New("dial tcp: connection refused"),
+	}
+	// Pré-condição: o *url.Error cru de fato vaza o telefone (senão o teste é vácuo).
+	if !strings.Contains(ue.Error(), phone) {
+		t.Fatalf("pré-condição falhou: *url.Error deveria conter o telefone: %q", ue.Error())
+	}
+
+	got := sanitizeURLError(ue)
+	if strings.Contains(got.Error(), phone) {
+		t.Fatalf("sanitizeURLError ainda vaza o telefone: %q", got.Error())
+	}
+	if strings.Contains(got.Error(), host) {
+		t.Fatalf("sanitizeURLError ainda vaza o host: %q", got.Error())
+	}
+	// O motivo é preservado (observabilidade do tipo de falha não regride).
+	if !strings.Contains(got.Error(), "connection refused") {
+		t.Fatalf("sanitizeURLError perdeu o motivo do erro: %q", got.Error())
+	}
+
+	// Erro que NÃO é *url.Error passa inalterado.
+	plain := errors.New("some other error")
+	if sanitizeURLError(plain) != plain {
+		t.Fatal("erro não-url.Error deveria passar inalterado")
+	}
+}

--- a/internal/services/data_relay_service.go
+++ b/internal/services/data_relay_service.go
@@ -51,9 +51,11 @@ func NewDataRelayService(logger *logrus.Logger, cfg *config.DataRelayConfig) *Da
 // SendErrorInterceptor sends callback error details to Data Relay
 // This is a fire-and-forget operation - errors are logged but not propagated
 func (s *DataRelayService) SendErrorInterceptor(ctx context.Context, payload ErrorInterceptorPayload) error {
+	// api_endpoint omitido do log: payload.APIEndpoint é o callback_url cru, que
+	// carrega o telefone do cidadão no path/query (LGPD). Ele segue no CORPO
+	// enviado ao Data Relay (o serviço precisa dele), mas não no stream de log.
 	logger := s.logger.WithFields(logrus.Fields{
 		"customer_number": payload.CustomerWhatsappNumber,
-		"api_endpoint":    payload.APIEndpoint,
 		"http_status":     payload.HTTPStatusCode,
 		"source":          payload.Source,
 		"flowname":        payload.FlowName,


### PR DESCRIPTION
O log debug ao guardar a callback URL logava a URL inteira, que **embute o telefone** do cidadão (`?phone=...`) — visto vazando ao vivo nos logs do Gateway durante teste gov.br. Troca o campo logado pra `message_id` (não-PII, já em escopo).

Lógica intacta; `go build` OK. Reviews: Claude (opus) APPROVE; Codex (gpt-5.5 xhigh) sem issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)