### PR TITLE
Fix GovBR OIDC endpoints and user info retrieval

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -19,18 +21,18 @@ import (
 
 // Server represents the HTTP server
 type Server struct {
-	config              *config.Config
-	logger              *logrus.Logger
-	router              *gin.Engine
-	httpServer          *http.Server
-	healthHandler       *handlers.HealthHandler
-	messageHandler      *handlers.MessageHandler
-	userActivityHandler *handlers.UserActivityHandler
+	config               *config.Config
+	logger               *logrus.Logger
+	router               *gin.Engine
+	httpServer           *http.Server
+	healthHandler        *handlers.HealthHandler
+	messageHandler       *handlers.MessageHandler
+	userActivityHandler  *handlers.UserActivityHandler
 	govBrCallbackHandler *handlers.GovBrCallbackHandler
-	redisService        *services.RedisService
-	rabbitMQService     *services.RabbitMQService
-	postgresService     *services.PostgresService
-	otelService         *services.OTelService // Optional OTel service
+	redisService         *services.RedisService
+	rabbitMQService      *services.RabbitMQService
+	postgresService      *services.PostgresService
+	otelService          *services.OTelService // Optional OTel service
 }
 
 // NewServer creates a new HTTP server
@@ -98,7 +100,7 @@ func NewServer(cfg *config.Config, logger *logrus.Logger, otelService *services.
 			}
 			return nil
 		}()),
-		userActivityHandler: handlers.NewUserActivityHandler(logger, cfg, redisService, postgresService),
+		userActivityHandler:  handlers.NewUserActivityHandler(logger, cfg, redisService, postgresService),
 		govBrCallbackHandler: handlers.NewGovBrCallbackHandler(logger, cfg, redisService, govbrRedisService),
 	}
 
@@ -214,6 +216,7 @@ func (s *Server) setupRoutes() {
 			govbr.GET("/callback", s.govBrCallbackHandler.HandleCallback)
 		}
 	}
+	s.registerGovBrRedirectCallbackAlias()
 
 	authInternal := s.router.Group("/api/v1/auth")
 	{
@@ -251,6 +254,29 @@ func (s *Server) setupRoutes() {
 			"path":    c.Request.URL.Path,
 		})
 	})
+}
+
+func (s *Server) registerGovBrRedirectCallbackAlias() {
+	redirectURI := strings.TrimSpace(s.config.GovBr.RedirectURI)
+	if redirectURI == "" {
+		return
+	}
+
+	parsedURL, err := url.Parse(redirectURI)
+	if err != nil {
+		s.logger.WithError(err).Warn("Invalid Gov.br redirect URI; skipping callback alias route")
+		return
+	}
+
+	callbackPath := parsedURL.EscapedPath()
+	if callbackPath == "" || callbackPath == "/auth/govbr/callback" {
+		return
+	}
+
+	if strings.HasSuffix(callbackPath, "/auth/govbr/callback") {
+		s.router.GET(callbackPath, s.govBrCallbackHandler.HandleCallback)
+		s.logger.WithField("path", callbackPath).Info("Registered Gov.br callback alias from redirect URI")
+	}
 }
 
 // setupHTTPServer configures the HTTP server

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -222,15 +222,33 @@ type CallbackConfig struct {
 
 // GovBrConfig holds configuration for Gov.br OAuth2/PKCE authentication
 type GovBrConfig struct {
-	ClientID      string `mapstructure:"GOVBR_CLIENT_ID"`
-	ClientSecret  string `mapstructure:"GOVBR_CLIENT_SECRET"`
-	RedirectURI   string `mapstructure:"GOVBR_REDIRECT_URI"`
-	AuthURL       string `mapstructure:"GOVBR_AUTH_URL"`
-	TokenURL      string `mapstructure:"GOVBR_TOKEN_URL"`
-	UserInfoURL   string `mapstructure:"GOVBR_USERINFO_URL"`   // UserInfo endpoint for fetching user data
-	Scope         string `mapstructure:"GOVBR_SCOPE"`
-	AuthStateTTL  int    `mapstructure:"GOVBR_AUTH_STATE_TTL"` // seconds
-	RedisURL      string `mapstructure:"GOVBR_REDIS_URL"`      // Redis URL for Gov.br tokens (shared with MCP)
+	ClientID     string `mapstructure:"GOVBR_CLIENT_ID"`
+	ClientSecret string `mapstructure:"GOVBR_CLIENT_SECRET"`
+	RedirectURI  string `mapstructure:"GOVBR_REDIRECT_URI"`
+	OIDCBaseURL  string `mapstructure:"GOVBR_OIDC_BASE_URL"`
+	Scope        string `mapstructure:"GOVBR_SCOPE"`
+	AuthStateTTL int    `mapstructure:"GOVBR_AUTH_STATE_TTL"` // seconds
+	RedisURL     string `mapstructure:"GOVBR_REDIS_URL"`      // Redis URL for Gov.br tokens (shared with MCP)
+}
+
+func (g GovBrConfig) AuthEndpoint() string {
+	return g.endpoint("auth")
+}
+
+func (g GovBrConfig) TokenEndpoint() string {
+	return g.endpoint("token")
+}
+
+func (g GovBrConfig) UserInfoEndpoint() string {
+	return g.endpoint("userinfo")
+}
+
+func (g GovBrConfig) endpoint(suffix string) string {
+	if g.OIDCBaseURL == "" {
+		return ""
+	}
+
+	return strings.TrimRight(g.OIDCBaseURL, "/") + "/" + suffix
 }
 
 type DataRelayConfig struct {
@@ -578,8 +596,7 @@ func bindEnvironmentVariables() {
 	_ = viper.BindEnv("GOVBR_CLIENT_ID")
 	_ = viper.BindEnv("GOVBR_CLIENT_SECRET")
 	_ = viper.BindEnv("GOVBR_REDIRECT_URI")
-	_ = viper.BindEnv("GOVBR_AUTH_URL")
-	_ = viper.BindEnv("GOVBR_TOKEN_URL")
+	_ = viper.BindEnv("GOVBR_OIDC_BASE_URL")
 	_ = viper.BindEnv("GOVBR_SCOPE")
 	_ = viper.BindEnv("GOVBR_AUTH_STATE_TTL")
 	_ = viper.BindEnv("GOVBR_REDIS_URL")

--- a/internal/handlers/govbr_callback.go
+++ b/internal/handlers/govbr_callback.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -20,14 +21,15 @@ import (
 type GovBrCallbackHandler struct {
 	logger            *logrus.Logger
 	config            *config.Config
-	redisService      RedisServiceInterface      // Main Redis (for auth state)
-	govbrRedisService RedisServiceInterface      // Gov.br specific Redis (for tokens, shared with MCP)
+	redisService      RedisServiceInterface // Main Redis (for auth state)
+	govbrRedisService RedisServiceInterface // Gov.br specific Redis (for tokens, shared with MCP)
 }
 
 // GovBrTokenResponse represents the token response from Identidade Carioca
 type GovBrTokenResponse struct {
 	AccessToken      string `json:"access_token"`
 	RefreshToken     string `json:"refresh_token"`
+	IDToken          string `json:"id_token"`
 	ExpiresIn        int    `json:"expires_in"`
 	RefreshExpiresIn int    `json:"refresh_expires_in"`
 	TokenType        string `json:"token_type"`
@@ -45,10 +47,11 @@ type GovBrAuthState struct {
 
 // GovBrUserInfo represents user data from /userinfo endpoint
 type GovBrUserInfo struct {
-	Sub   string `json:"sub"`   // Subject identifier (usually CPF)
-	Name  string `json:"name"`  // Full name
-	Email string `json:"email"` // Email (optional)
-	CPF   string `json:"cpf"`   // CPF (may be in sub or separate field)
+	Sub               string `json:"sub"`                // Subject identifier (usually CPF)
+	Name              string `json:"name"`               // Full name
+	Email             string `json:"email"`              // Email (optional)
+	CPF               string `json:"cpf"`                // CPF (may be in sub or separate field)
+	PreferredUsername string `json:"preferred_username"` // Common OIDC username claim
 }
 
 // NewGovBrCallbackHandler creates a new Gov.br callback handler
@@ -96,7 +99,6 @@ func (h *GovBrCallbackHandler) HandleCallback(c *gin.Context) {
 			"error":             errorParam,
 			"error_description": errorDescription,
 		}).Warn("Error returned by OAuth provider")
-
 
 		if errorDescription == "" {
 			errorDescription = "Erro durante o processo de autenticação"
@@ -146,8 +148,31 @@ func (h *GovBrCallbackHandler) HandleCallback(c *gin.Context) {
 		return
 	}
 
-	// Security: Validate state hasn't been tampered
 	if authState.State != "pending" {
+		if authState.State == "completed" {
+			logger.Debug("User clicked auth link again - checking if token still valid")
+
+			tokenStillValid := h.isTokenValid(ctx, authState.UserNumber)
+
+			if tokenStillValid {
+				logger.Info("Token still valid - showing success page for repeated click")
+				serviceName := formatServiceName(authState.ServiceContext)
+				c.HTML(http.StatusOK, "govbr_auth_success.html", gin.H{
+					"user_number": maskPhoneNumber(authState.UserNumber),
+					"service":     serviceName,
+				})
+				return
+			}
+
+			logger.Info("Token expired - showing error page")
+			c.HTML(http.StatusBadRequest, "govbr_auth_error.html", gin.H{
+				"error":       "token_expired",
+				"description": "Sua sessão expirou. Por favor, solicite um novo link de autenticação no WhatsApp.",
+				"ttl_minutes": h.config.GovBr.AuthStateTTL / 60,
+			})
+			return
+		}
+
 		logger.WithField("state", authState.State).Warn("Auth state is not pending")
 		c.HTML(http.StatusBadRequest, "govbr_auth_error.html", gin.H{
 			"error":       "invalid_state",
@@ -179,6 +204,11 @@ func (h *GovBrCallbackHandler) HandleCallback(c *gin.Context) {
 	if err != nil {
 		logger.WithError(err).Warn("Failed to fetch user info (non-critical)")
 		userInfo = nil
+	}
+	if idTokenUserInfo, err := parseUserInfoFromIDToken(tokenResp.IDToken); err == nil {
+		userInfo = mergeUserInfo(userInfo, idTokenUserInfo)
+	} else if tokenResp.IDToken != "" {
+		logger.WithError(err).Warn("Failed to parse user info from id_token")
 	}
 
 	// 6. Store tokens and user info in Redis with appropriate TTL
@@ -224,7 +254,7 @@ func (h *GovBrCallbackHandler) exchangeCodeForToken(
 	code string,
 	codeVerifier string,
 ) (*GovBrTokenResponse, error) {
-	tokenURL := h.config.GovBr.TokenURL
+	tokenURL := h.config.GovBr.TokenEndpoint()
 
 	data := url.Values{}
 	data.Set("grant_type", "authorization_code")
@@ -291,12 +321,11 @@ func (h *GovBrCallbackHandler) fetchUserInfo(
 	ctx context.Context,
 	accessToken string,
 ) (*GovBrUserInfo, error) {
-	if h.config.GovBr.UserInfoURL == "" {
+	userInfoURL := h.config.GovBr.UserInfoEndpoint()
+	if userInfoURL == "" {
 		h.logger.Debug("UserInfo URL not configured, skipping user data fetch")
 		return nil, nil
 	}
-
-	userInfoURL := h.config.GovBr.UserInfoURL
 
 	// Create request with Bearer token
 	req, err := http.NewRequestWithContext(
@@ -340,6 +369,9 @@ func (h *GovBrCallbackHandler) fetchUserInfo(
 	if userInfo.CPF == "" && userInfo.Sub != "" {
 		userInfo.CPF = userInfo.Sub
 	}
+	if userInfo.CPF == "" && userInfo.PreferredUsername != "" {
+		userInfo.CPF = userInfo.PreferredUsername
+	}
 
 	h.logger.WithFields(logrus.Fields{
 		"has_name":  userInfo.Name != "",
@@ -348,6 +380,80 @@ func (h *GovBrCallbackHandler) fetchUserInfo(
 	}).Debug("User info fetched successfully")
 
 	return &userInfo, nil
+}
+
+func parseUserInfoFromIDToken(idToken string) (*GovBrUserInfo, error) {
+	if idToken == "" {
+		return nil, nil
+	}
+
+	// The id_token has already been obtained through a successful token exchange.
+	// We only use its claims as profile enrichment, not as an authorization proof.
+	parts := strings.Split(idToken, ".")
+	if len(parts) < 2 {
+		return nil, fmt.Errorf("invalid id_token format")
+	}
+
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode id_token payload: %w", err)
+	}
+
+	var claims map[string]interface{}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return nil, fmt.Errorf("failed to parse id_token claims: %w", err)
+	}
+
+	userInfo := &GovBrUserInfo{
+		Sub:               firstStringClaim(claims, "sub"),
+		Name:              firstStringClaim(claims, "name", "nome"),
+		Email:             firstStringClaim(claims, "email"),
+		CPF:               firstStringClaim(claims, "cpf", "govbr_cpf", "preferred_username"),
+		PreferredUsername: firstStringClaim(claims, "preferred_username"),
+	}
+	if userInfo.CPF == "" && userInfo.Sub != "" {
+		userInfo.CPF = userInfo.Sub
+	}
+
+	return userInfo, nil
+}
+
+func mergeUserInfo(primary *GovBrUserInfo, fallback *GovBrUserInfo) *GovBrUserInfo {
+	if primary == nil {
+		return fallback
+	}
+	if fallback == nil {
+		return primary
+	}
+
+	if primary.Sub == "" {
+		primary.Sub = fallback.Sub
+	}
+	if primary.Name == "" {
+		primary.Name = fallback.Name
+	}
+	if primary.Email == "" {
+		primary.Email = fallback.Email
+	}
+	if primary.CPF == "" {
+		primary.CPF = fallback.CPF
+	}
+	if primary.PreferredUsername == "" {
+		primary.PreferredUsername = fallback.PreferredUsername
+	}
+
+	return primary
+}
+
+func firstStringClaim(claims map[string]interface{}, keys ...string) string {
+	for _, key := range keys {
+		value, ok := claims[key].(string)
+		if ok && value != "" {
+			return value
+		}
+	}
+
+	return ""
 }
 
 // storeTokens stores OAuth tokens in Redis with appropriate TTL
@@ -373,13 +479,13 @@ func (h *GovBrCallbackHandler) storeTokens(
 
 	// Prepare token data
 	tokenData := map[string]interface{}{
-		"access_token":        tokenResp.AccessToken,
-		"refresh_token":       tokenResp.RefreshToken,
-		"expires_at":          expiresAt,
-		"refresh_expires_at":  refreshExpiresAt,
-		"token_type":          tokenResp.TokenType,
-		"service_context":     serviceContext,
-		"created_at":          now.UTC().Format(time.RFC3339),
+		"access_token":       tokenResp.AccessToken,
+		"refresh_token":      tokenResp.RefreshToken,
+		"expires_at":         expiresAt,
+		"refresh_expires_at": refreshExpiresAt,
+		"token_type":         tokenResp.TokenType,
+		"service_context":    serviceContext,
+		"created_at":         now.UTC().Format(time.RFC3339),
 	}
 
 	// Add user info if available
@@ -404,9 +510,13 @@ func (h *GovBrCallbackHandler) storeTokens(
 		return fmt.Errorf("failed to marshal token data: %w", err)
 	}
 
-	// Store in Gov.br Redis (shared with MCP) with TTL = access token expiry
+	// Store in Gov.br Redis (shared with MCP). Keep the token record while the
+	// refresh token can still recover the session.
 	tokenKey := fmt.Sprintf("govbr_token:%s", sanitizedPhone)
 	ttl := time.Duration(tokenResp.ExpiresIn) * time.Second
+	if tokenResp.RefreshExpiresIn > tokenResp.ExpiresIn {
+		ttl = time.Duration(tokenResp.RefreshExpiresIn) * time.Second
+	}
 
 	if err := h.govbrRedisService.Set(ctx, tokenKey, string(tokenJSON), ttl); err != nil {
 		return fmt.Errorf("failed to store token in Gov.br Redis: %w", err)
@@ -444,15 +554,49 @@ func maskPhoneNumber(phone string) string {
 	return phone[:len(phone)-6] + "***"
 }
 
+func (h *GovBrCallbackHandler) isTokenValid(ctx context.Context, userNumber string) bool {
+	sanitizedPhone := sanitizePhoneNumber(userNumber)
+	tokenKey := fmt.Sprintf("govbr_token:%s", sanitizedPhone)
+
+	tokenJSON, err := h.govbrRedisService.Get(ctx, tokenKey)
+	if err != nil {
+		h.logger.WithError(err).Debug("Token not found in Redis")
+		return false
+	}
+
+	var tokenData map[string]interface{}
+	if err := json.Unmarshal([]byte(tokenJSON), &tokenData); err != nil {
+		h.logger.WithError(err).Warn("Failed to parse token data")
+		return false
+	}
+
+	expiresAt, ok := tokenData["expires_at"].(float64)
+	if !ok {
+		h.logger.Warn("Token missing expires_at field")
+		return false
+	}
+
+	now := time.Now().Unix()
+	isValid := now < int64(expiresAt)
+
+	h.logger.WithFields(logrus.Fields{
+		"expires_at": int64(expiresAt),
+		"now":        now,
+		"is_valid":   isValid,
+	}).Debug("Token validation result")
+
+	return isValid
+}
+
 // formatServiceName converts technical service_context to user-friendly name
 func formatServiceName(serviceContext string) string {
 	serviceNames := map[string]string{
-		"consulta_dados":    "Consulta de Dados",
-		"iptu":              "IPTU",
-		"multas":            "Consulta de Multas",
-		"processos":         "Processos",
-		"consultas_gerais":  "Consultas Gerais",
-		"chatbot-whatsapp":  "Chatbot WhatsApp",
+		"consulta_dados":           "Consulta de Dados",
+		"iptu":                     "IPTU",
+		"multas":                   "Consulta de Multas",
+		"processos":                "Processos",
+		"consultas_gerais":         "Consultas Gerais",
+		"chatbot-whatsapp":         "Chatbot WhatsApp",
 		"chatbot-whatsapp-staging": "Chatbot WhatsApp (Staging)",
 	}
 

--- a/internal/handlers/govbr_initiate.go
+++ b/internal/handlers/govbr_initiate.go
@@ -130,7 +130,7 @@ func (h *GovBrCallbackHandler) HandleInitiate(c *gin.Context) {
 	params.Set("code_challenge_method", "S256")
 	params.Set("kc_idp_hint", "govbr") // Force use of Gov.br identity provider
 
-	authURL := h.config.GovBr.AuthURL + "?" + params.Encode()
+	authURL := h.config.GovBr.AuthEndpoint() + "?" + params.Encode()
 
 	logger.WithField("state", state).Info("Gov.br auth session initiated")
 


### PR DESCRIPTION
## What Changed

- Centralizes GovBR endpoint configuration in `GOVBR_OIDC_BASE_URL`.
- Derives the `/auth`, `/token`, and `/userinfo` endpoints in code.
- Removes usage of `GOVBR_AUTH_URL`, `GOVBR_TOKEN_URL`, and `GOVBR_USERINFO_URL`.
- Fixes user data retrieval through the `/userinfo` endpoint.
- Adds an `id_token` fallback to enrich missing user profile fields.
- Registers a GovBR callback alias from `GOVBR_REDIRECT_URI`, supporting deployments behind a path prefix.
