### PR TITLE
feat(gateway): UX de erro no WhatsApp — classes, rate-limit, 1746 e métrica

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -137,6 +137,7 @@ type GoogleAgentEngineConfig struct {
 	// Graceful Error Messages
 	ErrorMessageTemporarilyUnavailable string `mapstructure:"GOOGLE_AGENT_ENGINE_ERROR_MSG_UNAVAILABLE"`
 	ErrorMessageTimeout                string `mapstructure:"GOOGLE_AGENT_ENGINE_ERROR_MSG_TIMEOUT"`
+	ErrorMessageRateLimited            string `mapstructure:"GOOGLE_AGENT_ENGINE_ERROR_MSG_RATELIMITED"`
 	ErrorMessageDefault                string `mapstructure:"GOOGLE_AGENT_ENGINE_ERROR_MSG_DEFAULT"`
 }
 
@@ -355,9 +356,10 @@ func setDefaults() {
 	viper.SetDefault("GOOGLE_AGENT_ENGINE_HEALTH_CHECK_RETRY_DELAY", "500ms")
 
 	// Google Agent Engine Graceful Error Messages
-	viper.SetDefault("GOOGLE_AGENT_ENGINE_ERROR_MSG_UNAVAILABLE", "🤖 Nosso serviço de IA está temporariamente indisponível. Por favor, tente novamente em alguns instantes.")
-	viper.SetDefault("GOOGLE_AGENT_ENGINE_ERROR_MSG_TIMEOUT", "⏱️ A resposta está demorando mais do que o esperado. Por favor, tente novamente.")
-	viper.SetDefault("GOOGLE_AGENT_ENGINE_ERROR_MSG_DEFAULT", "❌ Desculpe, ocorreu um erro ao processar sua mensagem. Por favor, tente novamente.")
+	viper.SetDefault("GOOGLE_AGENT_ENGINE_ERROR_MSG_UNAVAILABLE", "🤖 Nosso atendimento automático está fora do ar agora. Tente de novo em alguns minutos. Se precisar agora, fale com a Central 1746: ligue 1746 ou acesse 1746.rio.")
+	viper.SetDefault("GOOGLE_AGENT_ENGINE_ERROR_MSG_TIMEOUT", "⏳ A resposta está demorando mais que o normal. Pode enviar sua mensagem de novo?")
+	viper.SetDefault("GOOGLE_AGENT_ENGINE_ERROR_MSG_RATELIMITED", "🚦 Recebi muitas mensagens em pouco tempo. Aguarde alguns segundos e envie de novo, por favor.")
+	viper.SetDefault("GOOGLE_AGENT_ENGINE_ERROR_MSG_DEFAULT", "Tive um problema técnico ao processar sua mensagem. Pode tentar enviar de novo? Se continuar, fale com a Central 1746 (ligue 1746 ou acesse 1746.rio).")
 
 	// Audio Transcription
 	viper.SetDefault("TRANSCRIBE_MAX_DURATION", 60)
@@ -529,6 +531,7 @@ func bindEnvironmentVariables() {
 	_ = viper.BindEnv("GOOGLE_AGENT_ENGINE_HEALTH_CHECK_RETRY_DELAY")
 	_ = viper.BindEnv("GOOGLE_AGENT_ENGINE_ERROR_MSG_UNAVAILABLE")
 	_ = viper.BindEnv("GOOGLE_AGENT_ENGINE_ERROR_MSG_TIMEOUT")
+	_ = viper.BindEnv("GOOGLE_AGENT_ENGINE_ERROR_MSG_RATELIMITED")
 	_ = viper.BindEnv("GOOGLE_AGENT_ENGINE_ERROR_MSG_DEFAULT")
 
 	// EAI Agent

--- a/internal/services/google_agent_engine_service.go
+++ b/internal/services/google_agent_engine_service.go
@@ -869,9 +869,12 @@ func classifyEngineError(errStr string) string {
 
 	// Rate limit — must come before "unavailable"/"default": a 429 is distinct
 	// from a 5xx outage and deserves "aguarde alguns segundos", not "fora do ar".
+	// `429` é casado só no formato de status (`response: 429`), não como substring
+	// solta: erros de transporte do Go embutem a URL, que contém o engine/operation
+	// ID — um ID com "429" não deve virar rate-limit.
 	if strings.Contains(errStr, "rate limit") ||
 		strings.Contains(errStr, "too many requests") ||
-		strings.Contains(errStr, "429") {
+		strings.Contains(errStr, "response: 429") {
 		return "ratelimited"
 	}
 

--- a/internal/services/google_agent_engine_service.go
+++ b/internal/services/google_agent_engine_service.go
@@ -101,6 +101,19 @@ var (
 		},
 		[]string{"source"}, // source: redis/memory
 	)
+
+	// Conta qual mensagem de erro graciosa foi enviada ao cidadão quando o
+	// Gateway não consegue resposta do engine. Dá visibilidade da distribuição
+	// (timeout/unavailable/ratelimited/default) sem expor conteúdo da mensagem.
+	googleAgentEngineGracefulErrors = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "eai_gateway",
+			Subsystem: "google_agent_engine",
+			Name:      "graceful_error_messages_total",
+			Help:      "Total number of graceful error messages sent to the user, by class",
+		},
+		[]string{"error_class"}, // timeout/unavailable/ratelimited/default
+	)
 )
 
 // RedisServiceInterface is the interface for Redis operations needed by this service
@@ -301,13 +314,16 @@ func (s *GoogleAgentEngineService) SendMessage(ctx context.Context, threadID str
 
 		// Return graceful error message instead of returning error
 		// This prevents raw error propagation to the user
-		errorMsg := s.getGracefulErrorMessage(err)
+		errorClass := classifyEngineError(err.Error())
+		googleAgentEngineGracefulErrors.WithLabelValues(errorClass).Inc()
+		errorMsg := s.gracefulMessageForClass(errorClass)
 		responseContent = errorMsg
 
 		// Log the actual error but don't fail the request
 		s.logger.WithFields(logrus.Fields{
 			"thread_id":        threadID,
 			"error":            err.Error(),
+			"error_class":      errorClass,
 			"graceful_message": errorMsg,
 		}).Warn("Returning graceful error message to user")
 	}
@@ -844,28 +860,54 @@ func (s *GoogleAgentEngineService) performHealthCheck(ctx context.Context) error
 	return nil
 }
 
-// getGracefulErrorMessage returns a user-friendly error message based on the error type
-func (s *GoogleAgentEngineService) getGracefulErrorMessage(err error) string {
-	errStr := err.Error()
+// classifyEngineError maps an engine error string to a coarse class used both to
+// pick the user-facing message and to label the observability metric. Pure (no
+// config/state) so it is trivially unit-testable. Order matters — most specific
+// first.
+func classifyEngineError(errStr string) string {
+	errStr = strings.ToLower(errStr)
 
-	// Check for timeout errors
-	if strings.Contains(errStr, "timeout") ||
-		strings.Contains(errStr, "deadline exceeded") ||
-		strings.Contains(errStr, "context canceled") {
-		return s.config.GoogleAgentEngine.ErrorMessageTimeout
+	// Rate limit — must come before "unavailable"/"default": a 429 is distinct
+	// from a 5xx outage and deserves "aguarde alguns segundos", not "fora do ar".
+	if strings.Contains(errStr, "rate limit") ||
+		strings.Contains(errStr, "too many requests") ||
+		strings.Contains(errStr, "429") {
+		return "ratelimited"
 	}
 
-	// Check for availability errors
+	// Timeout — inclui "timed out" (com espaço), p.ex. "polling timed out after
+	// 30s", que NÃO casa com "timeout" e antes caía no default.
+	if strings.Contains(errStr, "timeout") ||
+		strings.Contains(errStr, "timed out") ||
+		strings.Contains(errStr, "deadline exceeded") ||
+		strings.Contains(errStr, "context canceled") {
+		return "timeout"
+	}
+
+	// Availability — engine fora do ar / erro de conexão / 5xx.
 	if strings.Contains(errStr, "connection refused") ||
 		strings.Contains(errStr, "unavailable") ||
 		strings.Contains(errStr, "503") ||
 		strings.Contains(errStr, "502") ||
 		strings.Contains(errStr, "504") {
-		return s.config.GoogleAgentEngine.ErrorMessageTemporarilyUnavailable
+		return "unavailable"
 	}
 
-	// Default error message for unknown errors
-	return s.config.GoogleAgentEngine.ErrorMessageDefault
+	return "default"
+}
+
+// gracefulMessageForClass maps an error class to the configured user-facing message.
+func (s *GoogleAgentEngineService) gracefulMessageForClass(class string) string {
+	switch class {
+	case "ratelimited":
+		return s.config.GoogleAgentEngine.ErrorMessageRateLimited
+	case "timeout":
+		return s.config.GoogleAgentEngine.ErrorMessageTimeout
+	case "unavailable":
+		return s.config.GoogleAgentEngine.ErrorMessageTemporarilyUnavailable
+	default:
+		return s.config.GoogleAgentEngine.ErrorMessageDefault
+	}
 }
 
 // SendHistoryUpdate sends multiple messages to update conversation history

--- a/internal/services/google_agent_engine_service.go
+++ b/internal/services/google_agent_engine_service.go
@@ -874,7 +874,14 @@ func classifyEngineError(errStr string) string {
 	// ID — um ID com "429" não deve virar rate-limit.
 	if strings.Contains(errStr, "rate limit") ||
 		strings.Contains(errStr, "too many requests") ||
-		strings.Contains(errStr, "response: 429") {
+		strings.Contains(errStr, "response: 429") ||
+		// Quota do Vertex/Google: surge como gRPC RESOURCE_EXHAUSTED ou texto
+		// "quota exceeded" — nem sempre com um 429 no formato de status. É um
+		// limite de taxa/quota, então merece "aguarde alguns segundos", não
+		// "fora do ar" (default/unavailable). Termos específicos, sem over-match.
+		strings.Contains(errStr, "resourceexhausted") ||
+		strings.Contains(errStr, "resource_exhausted") ||
+		strings.Contains(errStr, "quota exceeded") {
 		return "ratelimited"
 	}
 

--- a/internal/services/google_agent_engine_service_test.go
+++ b/internal/services/google_agent_engine_service_test.go
@@ -140,6 +140,9 @@ func TestClassifyEngineError(t *testing.T) {
 		{"rate limit exceeded", "rate limit exceeded: quota", "ratelimited"},
 		{"non-2xx 429", "non-2xx response: 429 - too many", "ratelimited"},
 		{"too many requests phrase", "engine returned Too Many Requests", "ratelimited"},
+		// 429 dentro de um ID/URL (não status) NÃO deve virar ratelimited
+		{"429 in engine id is not ratelimited", "Post \"https://.../reasoningEngines/429000111:query\": context deadline exceeded", "timeout"},
+		{"429 in id with no other signal is default", "failed for reasoningEngines/4290: boom", "default"},
 		// timeout — inclui "timed out" (gap corrigido)
 		{"polling timed out", "polling timed out after 30s", "timeout"},
 		{"context deadline", "context deadline exceeded", "timeout"},

--- a/internal/services/google_agent_engine_service_test.go
+++ b/internal/services/google_agent_engine_service_test.go
@@ -129,3 +129,42 @@ func BenchmarkStripBOM_WithoutBOM(b *testing.B) {
 		stripBOM(data)
 	}
 }
+
+func TestClassifyEngineError(t *testing.T) {
+	tests := []struct {
+		name     string
+		errStr   string
+		expected string
+	}{
+		// rate limit — mais específico, vem antes de unavailable/default
+		{"rate limit exceeded", "rate limit exceeded: quota", "ratelimited"},
+		{"non-2xx 429", "non-2xx response: 429 - too many", "ratelimited"},
+		{"too many requests phrase", "engine returned Too Many Requests", "ratelimited"},
+		// timeout — inclui "timed out" (gap corrigido)
+		{"polling timed out", "polling timed out after 30s", "timeout"},
+		{"context deadline", "context deadline exceeded", "timeout"},
+		{"literal timeout", "request timeout", "timeout"},
+		{"context canceled", "context canceled", "timeout"},
+		// availability — 5xx / conexão
+		{"503", "non-2xx response: 503 - service down", "unavailable"},
+		{"502", "non-2xx response: 502", "unavailable"},
+		{"504", "non-2xx response: 504", "unavailable"},
+		{"connection refused", "dial tcp: connection refused", "unavailable"},
+		{"unavailable word", "engine unavailable", "unavailable"},
+		// default — desconhecido
+		{"thread not found", "thread not found: abc", "default"},
+		{"500", "non-2xx response: 500 - internal", "default"},
+		{"marshal error", "failed to marshal request: bad", "default"},
+		{"empty", "", "default"},
+		// case-insensitive
+		{"uppercase RATE LIMIT", "RATE LIMIT EXCEEDED", "ratelimited"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := classifyEngineError(tt.errStr); got != tt.expected {
+				t.Errorf("classifyEngineError(%q) = %q, want %q", tt.errStr, got, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/services/google_agent_engine_service_test.go
+++ b/internal/services/google_agent_engine_service_test.go
@@ -140,6 +140,10 @@ func TestClassifyEngineError(t *testing.T) {
 		{"rate limit exceeded", "rate limit exceeded: quota", "ratelimited"},
 		{"non-2xx 429", "non-2xx response: 429 - too many", "ratelimited"},
 		{"too many requests phrase", "engine returned Too Many Requests", "ratelimited"},
+		// Quota do Vertex/Google → ratelimited (gRPC RESOURCE_EXHAUSTED / "quota exceeded")
+		{"grpc resource exhausted", "rpc error: code = ResourceExhausted desc = Quota exceeded for aiplatform.googleapis.com", "ratelimited"},
+		{"resource_exhausted underscore", "RESOURCE_EXHAUSTED: quota metric limit", "ratelimited"},
+		{"quota exceeded phrase", "Quota exceeded for quota metric 'Online prediction requests'", "ratelimited"},
 		// 429 dentro de um ID/URL (não status) NÃO deve virar ratelimited
 		{"429 in engine id is not ratelimited", "Post \"https://.../reasoningEngines/429000111:query\": context deadline exceeded", "timeout"},
 		{"429 in id with no other signal is default", "failed for reasoningEngines/4290: boom", "default"},


### PR DESCRIPTION
## Por que

Quando o **Gateway** não obtém resposta do engine, ele envia ao cidadão uma de 3
mensagens fixas (`getGracefulErrorMessage`, `google_agent_engine_service.go`).
Três problemas:

1. **Gap de classificação** — o erro de polling `"polling timed out after …"`
   não casa com `Contains(errStr, "timeout")` (é `"timed out"` com espaço) → caía
   na mensagem **DEFAULT** genérica em vez da de timeout.
2. **Sem classe de rate-limit** — `"rate limit exceeded"` e `"non-2xx response:
   429"` caíam no DEFAULT, sem orientar o cidadão a aguardar.
3. **Mensagens frias, sem fallback humano, sem métrica/teste.**

> Não confundir com a rede de segurança do engine ([#89](https://github.com/prefeitura-rio/app-eai-agent-engine/pull/89)): aquela cobre falha de tool **dentro** do engine (retorna 200 + fallback, que **bypassa** este classificador). Este PR cobre falha **Gateway↔engine** (down/timeout/5xx/rate-limit/resposta vazia). Camadas complementares.

## O que muda

- **`classifyEngineError(errStr)`** puro → classe `timeout|unavailable|ratelimited|default` (ordem: mais específico primeiro). Corrige `"timed out"` e adiciona rate-limit (`rate limit`/`429`/`too many requests`). Case-insensitive.
- **Nova mensagem** `GOOGLE_AGENT_ENGINE_ERROR_MSG_RATELIMITED` + wording mais quente dos 4 defaults. Erros **persistentes** (unavailable/default) apontam a **Central 1746** como fallback humano (decisão do produto).
- **Métrica** `eai_gateway_google_agent_engine_graceful_error_messages_total{error_class}` (package-level, padrão `promauto` do arquivo) + campo `error_class` no log estruturado — ops vê a distribuição sem expor o conteúdo da mensagem.
- **Teste** table-driven de `classifyEngineError` (18 casos; não havia teste pra essa lógica).

## Mensagens (defaults — ajustáveis via env / review)

| Classe | Mensagem |
|---|---|
| unavailable | 🤖 Nosso atendimento automático está fora do ar agora. Tente de novo em alguns minutos. Se precisar agora, fale com a Central 1746: ligue 1746 ou acesse 1746.rio. |
| timeout | ⏳ A resposta está demorando mais que o normal. Pode enviar sua mensagem de novo? |
| ratelimited | 🚦 Recebi muitas mensagens em pouco tempo. Aguarde alguns segundos e envie de novo, por favor. |
| default | Tive um problema técnico ao processar sua mensagem. Pode tentar enviar de novo? Se continuar, fale com a Central 1746 (ligue 1746 ou acesse 1746.rio). |

## Testes

`go build ./...`, `go vet ./internal/...`, `go test ./internal/services/ ./internal/config/` — verdes. `gofmt` limpo. Revisado via `codex review --uncommitted` (zero achados no conteúdo staged).

> E2E real (engine-down) exige derrubar o engine via infra — fora do escopo local; cobertura por unit test da classificação + build. Todas as mensagens são sobrescrevíveis por env (`GOOGLE_AGENT_ENGINE_ERROR_MSG_*`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
