### PR TITLE
chore(security): padroniza X-XSS-Protection: 0 (legado) no middleware de headers

### DIFF
--- a/internal/middleware/security.go
+++ b/internal/middleware/security.go
@@ -13,6 +13,13 @@ func SecurityHeaders() gin.HandlerFunc {
 		// Basic security headers
 		c.Header("X-Content-Type-Options", "nosniff")
 		c.Header("Referrer-Policy", "strict-origin-when-cross-origin")
+		// X-XSS-Protection is legacy: the XSS Auditor was removed from Chrome
+		// (M78) and Edge, and Firefox never shipped it; on old browsers
+		// `1; mode=block` was itself an info-leak/side-channel vector. We set
+		// `0` per the OWASP Secure Headers Project to explicitly disable the
+		// legacy auditor on every route. Real XSS protection comes from the
+		// per-route Content-Security-Policy below (issue #45).
+		c.Header("X-XSS-Protection", "0")
 
 		path := c.Request.URL.Path
 
@@ -25,12 +32,10 @@ func SecurityHeaders() gin.HandlerFunc {
 			// Gov.br callback renders first-party HTML templates with inline CSS.
 			// Keep fetches locked down while allowing the template stylesheet.
 			c.Header("X-Frame-Options", "DENY")
-			c.Header("X-XSS-Protection", "1; mode=block")
 			c.Header("Content-Security-Policy", "default-src 'none'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'")
 		} else {
 			// Strict CSP for API endpoints
 			c.Header("X-Frame-Options", "DENY")
-			c.Header("X-XSS-Protection", "1; mode=block")
 			c.Header("Content-Security-Policy", "default-src 'none'; frame-ancestors 'none'")
 		}
 

--- a/internal/middleware/security_test.go
+++ b/internal/middleware/security_test.go
@@ -32,6 +32,9 @@ func TestSecurityHeadersAllowsGovBrCallbackInlineStyles(t *testing.T) {
 	if got := rec.Header().Get("X-Frame-Options"); got != "DENY" {
 		t.Fatalf("expected X-Frame-Options DENY, got %q", got)
 	}
+	if got := rec.Header().Get("X-XSS-Protection"); got != "0" {
+		t.Fatalf("expected X-XSS-Protection 0 (legacy auditor disabled), got %q", got)
+	}
 }
 
 func TestSecurityHeadersKeepAPIEndpointsStrict(t *testing.T) {
@@ -50,5 +53,33 @@ func TestSecurityHeadersKeepAPIEndpointsStrict(t *testing.T) {
 
 	if got := rec.Header().Get("Content-Security-Policy"); got != "default-src 'none'; frame-ancestors 'none'" {
 		t.Fatalf("expected strict API CSP, got %q", got)
+	}
+	if got := rec.Header().Get("X-XSS-Protection"); got != "0" {
+		t.Fatalf("expected X-XSS-Protection 0 (legacy auditor disabled), got %q", got)
+	}
+}
+
+// TestSecurityHeadersDisableLegacyXSSAuditorOnAllRoutes pins issue #45: the
+// legacy X-XSS-Protection header must be a consistent "0" across every route
+// branch — Swagger UI (which previously omitted it entirely), the gov.br
+// callback, and the strict API default.
+func TestSecurityHeadersDisableLegacyXSSAuditorOnAllRoutes(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	for _, path := range []string{"/docs/index.html", "/swagger-ui", "/auth/govbr/callback", "/api/v1/health"} {
+		router := gin.New()
+		router.Use(SecurityHeaders())
+		router.GET(path, func(c *gin.Context) {
+			c.String(http.StatusOK, "ok")
+		})
+
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		rec := httptest.NewRecorder()
+
+		router.ServeHTTP(rec, req)
+
+		if got := rec.Header().Get("X-XSS-Protection"); got != "0" {
+			t.Fatalf("path %q: expected X-XSS-Protection 0, got %q", path, got)
+		}
 	}
 }


### PR DESCRIPTION
Fecha #45.

## O que muda
Padroniza `X-XSS-Protection: 0` (OWASP Secure Headers Project) nos 3 branches de `SecurityHeaders`, içando o header pro bloco de headers básicos (uniforme) e removendo os dois `1; mode=block` legados.

### Por quê
- O XSS Auditor é legado: removido do Chrome (M78) e do Edge, nunca implementado no Firefox; em navegadores antigos `1; mode=block` já foi vetor de info-leak/side-channel.
- A CSP forte (`default-src 'none'`) já cobre API e callback → o header não agrega proteção, só carrega risco legado.
- Estava inconsistente: API + callback setavam `1; mode=block`; o branch do Swagger UI não setava nada.

### Critério de aceite (#45)
- [x] `X-XSS-Protection` consistente (`0`) nos 3 branches de `SecurityHeaders`.
- [x] Teste por tipo de rota em `security_test.go` (Swagger, callback, API).
- [x] Racional registrado (comentário no código citando OWASP).

## Teste
`go test ./internal/middleware/` → 3 testes verdes (incl. o novo `TestSecurityHeadersDisableLegacyXSSAuditorOnAllRoutes`). Build + vet OK; suíte `./internal/...` verde.

> Nota: o repo tem um `pipelines/efficacy_eval_test.go` **untracked pré-existente** que quebra `go test ./...` (refs a símbolos ausentes) — não faz parte deste PR e não foi tocado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)