### PR TITLE
fix(redis): pool 20→50 — evita exaustão sob carga (incidente 2026-06-02)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -340,7 +340,11 @@ func setDefaults() {
 	viper.SetDefault("AGENT_ID_CACHE_TTL", "86400s")
 
 	// Redis Connection Pool
-	viper.SetDefault("REDIS_POOL_SIZE", 20)
+	// 50 (era 20): com ~100 consumers/pod (MAX_PARALLEL) um pool de 20 esgota sob carga
+	// e causa "context deadline exceeded" no Redis — inclusive na leitura do callback URL,
+	// fazendo a resposta morrer em silêncio (incidente 2026-06-02). Ver
+	// docs/propostas/plano-resiliencia-sobrecarga-2026-06-02.md (no repo study-sf).
+	viper.SetDefault("REDIS_POOL_SIZE", 50)
 	viper.SetDefault("REDIS_MIN_IDLE_CONNECTIONS", 5)
 	viper.SetDefault("REDIS_MAX_IDLE_CONNECTIONS", 10)
 	viper.SetDefault("REDIS_CONNECTION_MAX_IDLE_TIME", 300) // 5 minutes


### PR DESCRIPTION
## O quê

Sobe o default `REDIS_POOL_SIZE` **20 → 50** no gateway.

## Por quê (incidente 2026-06-02)

Sob carga (~100 consumers/pod via `MAX_PARALLEL`), o pool Redis de 20 **esgotava** →
`context deadline exceeded` nas operações Redis, **inclusive na leitura do callback URL**
→ a resposta ao cidadão **morria em silêncio** (663 no DLQ; uma msg de teste sem resposta).
Mais headroom no pool ataca diretamente essa causa.

## Escopo / segurança

- Mudança **mínima e segura** (revisada): `PoolSize` é o teto, não abre 50 conexões eager;
  não quebra `MIN/MAX_IDLE_CONNECTIONS` (5/10); env-overridable intacto (go-redis v9).
- **Os levers de maior impacto são env/infra** e dependem da **quota real de QPM do Vertex**
  — NÃO mexidos aqui de propósito (flipar default cego no código throttlaria prod):
  ligar o rate-limiter de QPM **que já existe** (`GOOGLE_API_RATE_LIMIT_ENABLED`, hoje
  `false`), calibrar `GOOGLE_API_MAX_REQUESTS_PER_MINUTE`, baixar `MAX_PARALLEL`, cap KEDA
  `maxReplicaCount`. Tudo em `docs/propostas/plano-resiliencia-sobrecarga-2026-06-02.md`
  (repo study-sf).
- **Follow-up:** atomicidade do limiter (race `GET`+`SET` → `INCR`/Lua), P1.4 do plano.

## Revisão

code-reviewer (opus) **APPROVE**; codex build+vet OK (o P1 do codex era do `pipelines/`
untracked de terceiros, fora deste PR).

## Deploy

O gateway builda `:latest` no merge; o pod pega no próximo roll. Seguro deployar a qualquer
momento (a carga do incidente já caiu). **Não mergeado** — fica a teu critério.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
