### PR TITLE
feat(engine): Onda 4 #11 — retry seguro do start da operação (pré-execução)

### DIFF
--- a/internal/services/google_agent_engine_service.go
+++ b/internal/services/google_agent_engine_service.go
@@ -114,6 +114,20 @@ var (
 		},
 		[]string{"error_class"}, // timeout/unavailable/ratelimited/default
 	)
+
+	// Conta os retries SEGUROS do start da operação (postQuery) em erros
+	// pré-execução, por outcome. "recovered" = um retry conseguiu iniciar a
+	// operação; "exhausted" = esgotou as tentativas e caiu no graceful message.
+	// Dá visibilidade de blips transitórios do engine sem expor conteúdo.
+	googleAgentEnginePostQueryRetries = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "eai_gateway",
+			Subsystem: "google_agent_engine",
+			Name:      "post_query_retries_total",
+			Help:      "Retries seguros do start da operação (postQuery) em erros pré-execução, por outcome.",
+		},
+		[]string{"outcome"}, // recovered/exhausted
+	)
 )
 
 // RedisServiceInterface is the interface for Redis operations needed by this service
@@ -561,9 +575,55 @@ func (s *GoogleAgentEngineService) queryReasoningEngine(ctx context.Context, thr
 		"reasoning_engine_id":  engineID,
 	}).Debug("Making async_query call to reasoning engine")
 
-	resp, err := s.postQuery(ctx, accessToken, payload, engineID)
-	if err != nil {
-		return "", fmt.Errorf("failed to post query: %w", err)
+	// Retry SEGURO do START da operação. Só re-tenta o postQuery (que inicia a
+	// operação async) em erros pré-execução (ver isPreExecutionRetriable): nesses
+	// a operação nunca começou no engine, então re-tentar não arrisca duplicar
+	// chamado. Timeout/502/504 NÃO entram — a operação pode ter rodado, então o
+	// erro sobe e vira graceful message (comportamento atual preservado). Reutiliza
+	// o config GOOGLE_AGENT_ENGINE_MAX_RETRIES (default 3) + RETRY_BACKOFF (1s).
+	maxAttempts := s.config.GoogleAgentEngine.MaxRetries
+	if maxAttempts < 1 {
+		maxAttempts = 1
+	}
+	backoff := s.config.GoogleAgentEngine.RetryBackoff
+	if backoff <= 0 {
+		// Guarda contra override 0s/negativo: sem espaçamento, os retries
+		// martelariam um engine já em apuros. Cai no mesmo default do config.
+		backoff = time.Second
+	}
+
+	var resp map[string]interface{}
+	for attempt := 1; ; attempt++ {
+		resp, err = s.postQuery(ctx, accessToken, payload, engineID)
+		if err == nil {
+			if attempt > 1 {
+				googleAgentEnginePostQueryRetries.WithLabelValues("recovered").Inc()
+				s.logger.WithFields(logrus.Fields{
+					"thread_id": threadID,
+					"attempt":   attempt,
+				}).Info("postQuery recuperou após retry de erro pré-execução")
+			}
+			break
+		}
+		// Para se o erro NÃO é seguro de re-tentar OU acabaram as tentativas.
+		if !isPreExecutionRetriable(err.Error()) || attempt >= maxAttempts {
+			if attempt > 1 {
+				googleAgentEnginePostQueryRetries.WithLabelValues("exhausted").Inc()
+			}
+			return "", fmt.Errorf("failed to post query: %w", err)
+		}
+		s.logger.WithFields(logrus.Fields{
+			"thread_id": threadID,
+			"attempt":   attempt,
+			"max":       maxAttempts,
+			"error":     err.Error(),
+		}).Warn("postQuery falhou com erro pré-execução; re-tentando o start da operação")
+		// Respeita o cancelamento/deadline do contexto durante o backoff.
+		select {
+		case <-ctx.Done():
+			return "", fmt.Errorf("contexto encerrado durante retry do postQuery: %w", ctx.Err())
+		case <-time.After(backoff):
+		}
 	}
 
 	opName := s.extractOperationName(resp)
@@ -906,6 +966,50 @@ func classifyEngineError(errStr string) string {
 	return "default"
 }
 
+// isPreExecutionRetriable diz se um erro do START da operação (postQuery) é
+// seguro de re-tentar — i.e., a operação async PROVAVELMENTE nunca começou no
+// engine, então re-tentar NÃO arrisca duplicar efeito colateral (ex: abrir o
+// MESMO chamado SGRC duas vezes). O graph do engine é NÃO-idempotente, então a
+// regra é conservadora:
+//
+//   - SEGURO (true): conexão recusada (TCP nunca conectou) ou o servidor
+//     REJEITOU explicitamente antes de aceitar (503 / gRPC UNAVAILABLE). Nesses
+//     casos a operação não foi criada.
+//   - INSEGURO (false): timeout / deadline / context canceled / 502 / 504 — a
+//     requisição pode ter sido recebida e a operação iniciada (e ter rodado tools
+//     com efeito colateral) antes do erro. Nunca re-tentar.
+//
+// Pure (sem config/estado) — trivialmente testável. As exclusões vêm primeiro:
+// se o erro casar QUALQUER sinal inseguro, retorna false mesmo que também
+// contenha "unavailable".
+//
+// Status HTTP (502/503/504) são casados na forma canônica do postQuery
+// (`response: 50X`, ver o erro montado em postQuery), NÃO como substring solta —
+// mesmo cuidado do classifyEngineError com "429": um erro de transporte embute a
+// URL com o reasoningEngine ID, e um ID com esses dígitos não deve influenciar a
+// decisão. Os sinais semânticos (connection refused / unavailable / timeout /
+// deadline / context canceled) ficam por palavra (não aparecem em IDs numéricos).
+func isPreExecutionRetriable(errStr string) bool {
+	s := strings.ToLower(errStr)
+
+	// Inseguro: pode ter executado. Exclusão tem prioridade. 502/504 são erros de
+	// proxy onde a operação pode ter iniciado no backend antes do erro.
+	if strings.Contains(s, "timeout") ||
+		strings.Contains(s, "timed out") ||
+		strings.Contains(s, "deadline exceeded") ||
+		strings.Contains(s, "context canceled") ||
+		strings.Contains(s, "response: 502") ||
+		strings.Contains(s, "response: 504") {
+		return false
+	}
+
+	// Seguro: a operação não chegou a ser criada (TCP nunca conectou, ou o servidor
+	// rejeitou explicitamente com 503 / gRPC UNAVAILABLE antes de aceitar).
+	return strings.Contains(s, "connection refused") ||
+		strings.Contains(s, "response: 503") ||
+		strings.Contains(s, "unavailable")
+}
+
 // gracefulMessageForClass maps an error class to the configured user-facing message.
 func (s *GoogleAgentEngineService) gracefulMessageForClass(class string) string {
 	switch class {
@@ -998,6 +1102,9 @@ func (s *GoogleAgentEngineService) SendHistoryUpdate(ctx context.Context, thread
 		"reasoning_engine_id": engineID,
 	}).Debug("Making async_query call with type=history to reasoning engine")
 
+	// Caminho type=history (atualização de histórico) intencionalmente SEM o retry
+	// pré-execução do turno ao vivo: aqui não há resposta entregue ao cidadão nem
+	// abertura de chamado, então não vale a complexidade; uma falha apenas propaga.
 	resp, err := s.postQuery(ctx, accessToken, payload, engineID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to post query: %w", err)

--- a/internal/services/google_agent_engine_service.go
+++ b/internal/services/google_agent_engine_service.go
@@ -992,12 +992,15 @@ func classifyEngineError(errStr string) string {
 func isPreExecutionRetriable(errStr string) bool {
 	s := strings.ToLower(errStr)
 
-	// Inseguro: pode ter executado. Exclusão tem prioridade. 502/504 são erros de
-	// proxy onde a operação pode ter iniciado no backend antes do erro.
+	// Inseguro: pode ter executado. Exclusão tem prioridade. 500/502/504 são erros
+	// onde a operação pode ter iniciado no backend antes do erro (500 é ambíguo —
+	// o servidor pode ter criado a LRO e então falhado ao responder; nunca assumir
+	// pré-execução). Só 503 / gRPC UNAVAILABLE / connection refused são limpos.
 	if strings.Contains(s, "timeout") ||
 		strings.Contains(s, "timed out") ||
 		strings.Contains(s, "deadline exceeded") ||
 		strings.Contains(s, "context canceled") ||
+		strings.Contains(s, "response: 500") ||
 		strings.Contains(s, "response: 502") ||
 		strings.Contains(s, "response: 504") {
 		return false

--- a/internal/services/google_agent_engine_service_test.go
+++ b/internal/services/google_agent_engine_service_test.go
@@ -192,6 +192,7 @@ func TestIsPreExecutionRetriable(t *testing.T) {
 		{"timed out", "polling timed out after 30s", false},
 		{"deadline exceeded", "context deadline exceeded", false},
 		{"context canceled", "context canceled", false},
+		{"500 whose body says unavailable is still unsafe", "non-2xx response: 500 - backend reported unavailable", false},
 		{"502 bad gateway", "non-2xx response: 502 - bad gateway", false},
 		{"504 gateway timeout", "non-2xx response: 504 - gateway timeout", false},
 

--- a/internal/services/google_agent_engine_service_test.go
+++ b/internal/services/google_agent_engine_service_test.go
@@ -175,3 +175,47 @@ func TestClassifyEngineError(t *testing.T) {
 		})
 	}
 }
+
+func TestIsPreExecutionRetriable(t *testing.T) {
+	tests := []struct {
+		name   string
+		errStr string
+		want   bool
+	}{
+		// SEGURO: a operação async nunca começou no engine.
+		{"connection refused", "failed to make request: dial tcp: connect: connection refused", true},
+		{"503 status", "non-2xx response: 503 - service unavailable", true},
+		{"unavailable word", "rpc error: code = Unavailable desc = the service is currently unavailable", true},
+
+		// INSEGURO: pode ter executado (criado chamado) → nunca re-tentar.
+		{"plain timeout", "request timeout", false},
+		{"timed out", "polling timed out after 30s", false},
+		{"deadline exceeded", "context deadline exceeded", false},
+		{"context canceled", "context canceled", false},
+		{"502 bad gateway", "non-2xx response: 502 - bad gateway", false},
+		{"504 gateway timeout", "non-2xx response: 504 - gateway timeout", false},
+
+		// CRÍTICO: exclusão tem prioridade — "unavailable"/"503" + sinal inseguro → false.
+		{"503 but also timed out", "non-2xx response: 503 - upstream timed out", false},
+		{"unavailable but deadline", "unavailable: context deadline exceeded", false},
+		{"504 response whose body mentions unavailable", "non-2xx response: 504 - upstream service unavailable", false},
+
+		// Status casado na forma canônica: um ID com 503 (não "response: 503") e
+		// sem sinal transitório real NÃO deve ser re-tentado (mesmo guard do "429").
+		{"503 in engine id is not retriable", "non-2xx response: 500 - boom referencing 503 elsewhere", false},
+
+		// Fora do conjunto seguro → false (não re-tenta).
+		{"500 internal", "non-2xx response: 500 - internal server error", false},
+		{"rate limit", "rate limit exceeded: quota", false},
+		{"thread not found", "thread not found: abc", false},
+		{"empty", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isPreExecutionRetriable(tt.errStr); got != tt.want {
+				t.Errorf("isPreExecutionRetriable(%q) = %v, want %v", tt.errStr, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Onda 4 #11 — retry seguro do start da operação em erros pré-execução

Melhora a resiliência a **blips transitórios** do engine (pod reiniciando, 503 breve, conexão recusada) sem arriscar duplicar efeito colateral. Hoje qualquer falha de `queryReasoningEngine` vira imediatamente um "problema técnico" pro cidadão.

> ⚠️ Rollout via ArgoCD/infra — não-deployável pelo autor. PR pronto pra revisão+deploy de infra.

### Segurança (o ponto central)
O graph do engine é **NÃO-idempotente** (um turno abre chamado SGRC, manda mensagens). Re-tentar algo que *talvez* executou duplicaria. Por isso o retry é estreito:
- Envolve **só o `postQuery`** (que INICIA a operação async). Depois que a operação começou, nada é re-tentado — o poll e seus erros seguem intactos.
- Só re-tenta em erros **pré-execução** (`isPreExecutionRetriable`): `connection refused` / `503` / gRPC `UNAVAILABLE` — a operação provadamente nunca foi criada. **NUNCA** em `timeout`/`deadline`/`context canceled`/`502`/`504` (poderiam ter executado). Exclusões têm prioridade; status casados na forma canônica `response: 50X` (evita over-match de ID, igual ao guard de "429").

### Mecânica
- Fia o config **órfão** `GOOGLE_AGENT_ENGINE_MAX_RETRIES` (default 3) + `GOOGLE_AGENT_ENGINE_RETRY_BACKOFF` (default 1s, com piso contra override 0s) — declarados mas nunca usados.
- Métrica `post_query_retries_total{outcome=recovered|exhausted}`.
- Respeita `ctx.Done()` no backoff. Caminho `type=history` sem retry (sem resposta ao cidadão).
- **Comportamento preservado**: esgotou ou erro não-seguro → mesmo graceful message de antes.

### Validação
- Predicado puro 100% testado, ênfase nos casos de segurança (502/504/timeout → nunca re-tenta, mesmo com "unavailable" presente).
- `go build ./...` + `go vet` + `gofmt` limpos; suíte do pacote `services` verde.
- code-reviewer opus: **sem blockers**; achados aplicados (forma canônica de status, piso do backoff, comentário no caller de history).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
