### PR TITLE
fix(gateway): init-container espera redis-valkey (migração Redis→Valkey)

### DIFF
--- a/k8s/staging/resources.yaml
+++ b/k8s/staging/resources.yaml
@@ -29,7 +29,7 @@ spec:
       initContainers:
         - name: wait-for-redis
           image: busybox:1.36
-          command: ['sh', '-c', 'until nc -z redis-master 6379; do echo "waiting for redis..."; sleep 2; done; echo "redis is ready"']
+          command: ['sh', '-c', 'until nc -z redis-valkey 6379; do echo "waiting for redis..."; sleep 2; done; echo "redis is ready"']
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true


### PR DESCRIPTION
## Incidente
A migração fleet-wide **Redis→Valkey** (Terraform, 2026-06-15 21:08 UTC) renomeou o service `redis-master`→`redis-valkey`, mas **não atualizou os consumidores**. O gateway tinha `redis-master` hardcoded em **dois** lugares:
1. `REDIS_DSN`/`REDIS_BACKEND` no **Infisical** — já corrigido pra `redis-valkey`.
2. O **init-container `wait-for-redis`** neste manifesto (`k8s/staging/resources.yaml`) — **este PR**.

Com o (2) ainda em `redis-master`, novos pods do gateway **travam em Init** (`until nc -z redis-master` nunca resolve) → gateway 503 em `/ready` → **bot fora do ar (~3h)**.

## Fix
Repointa o init-container pro host novo `redis-valkey`. Mitigação temporária já aplicada via `kubectl patch` (revertida pelo ArgoCD selfHeal) — este PR torna durável (ArgoCD sincroniza do git).

## Validação
- Confirmado que `redis-valkey` aceita as credenciais atuais do gateway (`redis-cli -a … ping` → PONG; senha idêntica à do `redis-master` antigo).
- Pod com este init-container subiu `2/2 Ready` no cluster.

## Escopo
Só **staging** (ns `eai-agent-gateway`, onde o Redis já é valkey). **Prod** (`k8s/prod/resources.yaml` tem o mesmo `redis-master`) fica para PR próprio após confirmar a migração + Infisical de prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)