### PR TITLE
fix(gateway): aceitar message_type=reaction (#10)

### DIFF
--- a/internal/models/message.go
+++ b/internal/models/message.go
@@ -18,6 +18,7 @@ var KnownMessageTypesList = []string{
 	"video",
 	"location",
 	"interactive",
+	"reaction",
 	"unsupported",
 	"unknown",
 }
@@ -41,9 +42,13 @@ func IsKnownMessageType(messageType string) bool {
 }
 
 // AllowsEmptyMedia reports whether message_type can carry only its sentinel
-// classification without a media metadata object.
+// classification (or extra_metadata) without a media metadata object and without
+// a non-empty message. "reaction" carries the emoji in extra_metadata, not media,
+// and has no message body — so it must be allowed here, otherwise the Mule
+// meta-webhook forward (message_type="reaction", message="", media=null) is
+// rejected with 400 and the bot goes mute on emoji reactions (#10).
 func AllowsEmptyMedia(messageType string) bool {
-	return messageType == "unsupported" || messageType == "unknown"
+	return messageType == "unsupported" || messageType == "unknown" || messageType == "reaction"
 }
 
 // HistoryMessage represents a single message in the history update

--- a/internal/models/message_test.go
+++ b/internal/models/message_test.go
@@ -17,6 +17,7 @@ func TestIsKnownMessageType(t *testing.T) {
 		{name: "interactive", messageType: "interactive", want: true},
 		{name: "unsupported sentinel", messageType: "unsupported", want: true},
 		{name: "unknown sentinel", messageType: "unknown", want: true},
+		{name: "reaction", messageType: "reaction", want: true},
 		{name: "typo", messageType: "imgae", want: false},
 		{name: "outbound-only registry type", messageType: "document", want: false},
 	}
@@ -37,6 +38,7 @@ func TestAllowsEmptyMedia(t *testing.T) {
 	}{
 		{messageType: "unsupported", want: true},
 		{messageType: "unknown", want: true},
+		{messageType: "reaction", want: true},
 		{messageType: "interactive", want: false},
 		{messageType: "image", want: false},
 		{messageType: "", want: false},


### PR DESCRIPTION
## #10 — reaction quebra contrato Mule→Gateway (bot-mudo)
O Mule encaminha reações (emoji do cidadão) como `message_type="reaction"` (message="", media=null). O gateway rejeitava com **400** ("reaction" não estava em `KnownMessageTypesList` nem `AllowsEmptyMedia`).

## Fix
- `reaction` em `KnownMessageTypesList` → passa `IsKnownMessageType`.
- `reaction` em `AllowsEmptyMedia` → passa o guard 'message OR media required' (reaction só tem o emoji, sem message/media).
- +2 testes (`IsKnownMessageType`, `AllowsEmptyMedia`). `go build` + `go test` OK.

## Deferral documentado (codex P2)
O emoji vem em `extra_metadata`, sem campo no `UserWebhookRequest`/`QueueMessage` (Gin dropa) → a reação chega ao engine **sem o emoji**. **Aceitável:** a reação é não-acionável — o engine a trata como sem-conteúdo → resposta vazia → **silenciada pelo Mule #60**. Propagar o emoji (sentiment) é enhancement cross-layer futuro (campo no struct + formato `[INBOUND_MEDIA]` + prompt do engine), sem consumidor hoje. O objetivo do #10 (parar o 400/bot-mudo) está atingido.

🤖 Generated with [Claude Code](https://claude.com/claude-code)