### PR TITLE
fix(gateway): data races + rate limiter atômico (#13)

### DIFF
--- a/internal/services/google_agent_engine_service.go
+++ b/internal/services/google_agent_engine_service.go
@@ -122,6 +122,9 @@ type RedisServiceInterface interface {
 	Set(ctx context.Context, key string, value string, ttl time.Duration) error
 	SetValue(ctx context.Context, key string, value interface{}, ttl time.Duration) error
 	Delete(ctx context.Context, key string) error
+	// Incr/Expire: INCR atômico + TTL pro rate limiter (evita TOCTOU get+set, #13).
+	Incr(ctx context.Context, key string) (int64, error)
+	Expire(ctx context.Context, key string, ttl time.Duration) error
 }
 
 // createTokenSourceFromCredentials creates a token source directly from credentials JSON

--- a/internal/services/message_consumer.go
+++ b/internal/services/message_consumer.go
@@ -47,7 +47,7 @@ func (r *RabbitMQService) ConsumeMessages(ctx context.Context, queueName string,
 	r.mutex.RLock()
 	defer r.mutex.RUnlock()
 
-	if !r.isConnected {
+	if !r.isConnected.Load() {
 		return fmt.Errorf("RabbitMQ connection is not available")
 	}
 
@@ -88,7 +88,7 @@ func (r *RabbitMQService) StartConsumer(ctx context.Context, queueName string, c
 	r.mutex.RLock()
 	defer r.mutex.RUnlock()
 
-	if !r.isConnected {
+	if !r.isConnected.Load() {
 		return fmt.Errorf("RabbitMQ connection is not available")
 	}
 
@@ -315,6 +315,16 @@ func (c *Consumer) publishRetryMessage(originalMsg amqp.Delivery, retryCount int
 				headers[k] = v
 			}
 		}
+	}
+
+	// #13: publish sob RLock do RabbitMQService. Sem isso c.rabbitMQ.channel era lido
+	// SEM sincronização enquanto o reconnect o substitui sob Lock (data race, pego por
+	// `go test -race`). Mesmo padrão das PublishMessage. isConnected agora é atomic.Bool.
+	c.rabbitMQ.mutex.RLock()
+	defer c.rabbitMQ.mutex.RUnlock()
+	if !c.rabbitMQ.isConnected.Load() || c.rabbitMQ.channel == nil {
+		logger.Error("Cannot publish retry message: RabbitMQ not connected")
+		return
 	}
 
 	// Publish retry message

--- a/internal/services/rabbitmq_service.go
+++ b/internal/services/rabbitmq_service.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	amqp "github.com/rabbitmq/amqp091-go"
@@ -20,13 +21,13 @@ type RabbitMQService struct {
 	connection  *amqp.Connection
 	channel     *amqp.Channel
 	mutex       sync.RWMutex
-	isConnected bool
+	isConnected atomic.Bool
 
 	// Connection monitoring
 	notifyConnClose chan *amqp.Error
 	notifyChanClose chan *amqp.Error
 	notifyReconnect chan bool
-	isShutdown      bool
+	isShutdown      atomic.Bool
 
 	// Reconnect broadcast: closed and replaced on every successful reconnect.
 	// Consumer goroutines wait on the channel returned by ReconnectedCh() to
@@ -108,7 +109,7 @@ func (r *RabbitMQService) connect() error {
 
 	r.connection = conn
 	r.channel = ch
-	r.isConnected = true
+	r.isConnected.Store(true)
 
 	// Setup connection monitoring
 	r.notifyConnClose = make(chan *amqp.Error)
@@ -238,7 +239,7 @@ func (r *RabbitMQService) PublishMessage(ctx context.Context, queueName string, 
 	r.mutex.RLock()
 	defer r.mutex.RUnlock()
 
-	if !r.isConnected {
+	if !r.isConnected.Load() {
 		return fmt.Errorf("RabbitMQ connection is not available")
 	}
 
@@ -285,7 +286,7 @@ func (r *RabbitMQService) PublishMessageWithHeaders(ctx context.Context, queueNa
 	r.mutex.RLock()
 	defer r.mutex.RUnlock()
 
-	if !r.isConnected {
+	if !r.isConnected.Load() {
 		return fmt.Errorf("RabbitMQ connection is not available")
 	}
 
@@ -341,7 +342,7 @@ func (r *RabbitMQService) PublishMessageWithDelay(ctx context.Context, queueName
 	r.mutex.RLock()
 	defer r.mutex.RUnlock()
 
-	if !r.isConnected {
+	if !r.isConnected.Load() {
 		return fmt.Errorf("RabbitMQ connection is not available")
 	}
 
@@ -385,7 +386,7 @@ func (r *RabbitMQService) PublishPriorityMessage(ctx context.Context, queueName 
 	r.mutex.RLock()
 	defer r.mutex.RUnlock()
 
-	if !r.isConnected {
+	if !r.isConnected.Load() {
 		return fmt.Errorf("RabbitMQ connection is not available")
 	}
 
@@ -424,23 +425,23 @@ func (r *RabbitMQService) handleReconnect() {
 	for {
 		select {
 		case err := <-r.notifyConnClose:
-			if r.isShutdown {
+			if r.isShutdown.Load() {
 				return
 			}
 			r.logger.WithError(err).Error("RabbitMQ connection lost, attempting to reconnect")
-			r.isConnected = false
+			r.isConnected.Store(false)
 			r.reconnect()
 
 		case err := <-r.notifyChanClose:
-			if r.isShutdown {
+			if r.isShutdown.Load() {
 				return
 			}
 			r.logger.WithError(err).Error("RabbitMQ channel lost, attempting to reconnect")
-			r.isConnected = false
+			r.isConnected.Store(false)
 			r.reconnect()
 
 		case <-r.notifyReconnect:
-			if r.isShutdown {
+			if r.isShutdown.Load() {
 				return
 			}
 			r.logger.Info("Manual reconnection requested")
@@ -459,7 +460,7 @@ func (r *RabbitMQService) reconnect() {
 	infiniteRetries := maxRetries < 0
 
 	for infiniteRetries || retryCount < maxRetries {
-		if r.isShutdown {
+		if r.isShutdown.Load() {
 			return
 		}
 
@@ -501,7 +502,7 @@ func (r *RabbitMQService) HealthCheck(ctx context.Context) error {
 	r.mutex.RLock()
 	defer r.mutex.RUnlock()
 
-	if !r.isConnected || r.connection == nil || r.connection.IsClosed() {
+	if !r.isConnected.Load() || r.connection == nil || r.connection.IsClosed() {
 		return fmt.Errorf("RabbitMQ connection is not available")
 	}
 
@@ -534,7 +535,7 @@ func (r *RabbitMQService) GetQueueInfo(queueName string) (amqp.Queue, error) {
 	r.mutex.RLock()
 	defer r.mutex.RUnlock()
 
-	if !r.isConnected {
+	if !r.isConnected.Load() {
 		return amqp.Queue{}, fmt.Errorf("RabbitMQ connection is not available")
 	}
 
@@ -546,8 +547,8 @@ func (r *RabbitMQService) Close() error {
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
 
-	r.isShutdown = true
-	r.isConnected = false
+	r.isShutdown.Store(true)
+	r.isConnected.Store(false)
 
 	if r.channel != nil {
 		if err := r.channel.Close(); err != nil {
@@ -570,7 +571,7 @@ func (r *RabbitMQService) Close() error {
 func (r *RabbitMQService) IsConnected() bool {
 	r.mutex.RLock()
 	defer r.mutex.RUnlock()
-	return r.isConnected
+	return r.isConnected.Load()
 }
 
 // TriggerReconnect manually triggers a reconnection attempt
@@ -608,7 +609,7 @@ func (r *RabbitMQService) ConsumeQueue(queueName, consumerTag string) (<-chan am
 	r.mutex.RLock()
 	defer r.mutex.RUnlock()
 
-	if !r.isConnected {
+	if !r.isConnected.Load() {
 		return nil, fmt.Errorf("RabbitMQ not connected")
 	}
 

--- a/internal/services/rate_limiter_service.go
+++ b/internal/services/rate_limiter_service.go
@@ -38,26 +38,21 @@ func (r *RateLimiterService) Allow(ctx context.Context, key string) (bool, error
 		return true, nil
 	}
 
-	// Get current count
-	count, err := r.getCurrentCount(ctx, key)
+	// #13: INCR atômico em vez de get→check→set. O padrão anterior tinha TOCTOU —
+	// entre o GET e o INCR, requests concorrentes liam a MESMA contagem e passavam
+	// todas, estourando o limite. Agora a contagem é incrementada e lida numa única
+	// operação atômica; `newCount` JÁ inclui esta request.
+	newCount, err := r.incrementCount(ctx, key)
 	if err != nil {
-		r.logger.WithError(err).WithField("key", key).Error("Failed to get current rate limit count")
+		r.logger.WithError(err).WithField("key", key).Error("Failed to increment rate limit count")
 		return false, err
 	}
 
-	allowed := count < r.config.GoogleCloud.MaxRequestsPerMinute
-
-	if allowed {
-		// Increment the count
-		if err := r.incrementCount(ctx, key); err != nil {
-			r.logger.WithError(err).WithField("key", key).Error("Failed to increment rate limit count")
-			return false, err
-		}
-	}
+	allowed := newCount <= r.config.GoogleCloud.MaxRequestsPerMinute
 
 	r.logger.WithFields(logrus.Fields{
 		"key":     key,
-		"count":   count,
+		"count":   newCount,
 		"limit":   r.config.GoogleCloud.MaxRequestsPerMinute,
 		"allowed": allowed,
 	}).Debug("Rate limit check")
@@ -115,27 +110,6 @@ func (r *RateLimiterService) Wait(ctx context.Context, key string) error {
 	return fmt.Errorf("rate limit exceeded after %d attempts for key: %s", maxRetries, key)
 }
 
-// getCurrentCount gets the current request count for the key in the current minute window
-func (r *RateLimiterService) getCurrentCount(ctx context.Context, key string) (int, error) {
-	// Use current minute as the window
-	now := time.Now()
-	windowKey := fmt.Sprintf("rate_limit:%s:%d", key, now.Unix()/60)
-
-	countStr, err := r.redisService.Get(ctx, windowKey)
-	if err != nil {
-		// If key doesn't exist, count is 0
-		return 0, nil
-	}
-
-	count, err := strconv.Atoi(countStr)
-	if err != nil {
-		r.logger.WithError(err).WithField("window_key", windowKey).Warn("Invalid rate limit count in Redis, resetting to 0")
-		return 0, nil
-	}
-
-	return count, nil
-}
-
 // getCurrentCountForUsage gets the current request count and distinguishes between missing keys and Redis errors
 func (r *RateLimiterService) getCurrentCountForUsage(ctx context.Context, key string) (int, error) {
 	// Use current minute as the window
@@ -161,26 +135,27 @@ func (r *RateLimiterService) getCurrentCountForUsage(ctx context.Context, key st
 	return count, nil
 }
 
-// incrementCount increments the request count for the current minute window
-func (r *RateLimiterService) incrementCount(ctx context.Context, key string) error {
-	// Use current minute as the window
+// incrementCount atomically increments the request count for the current minute
+// window via Redis INCR (#13: substitui o get→set anterior, que não era atômico) e
+// retorna a NOVA contagem, já incluindo esta request. Seta o TTL na primeira request
+// do window (best-effort — a chave é minuto-scoped, o TTL é só cleanup).
+func (r *RateLimiterService) incrementCount(ctx context.Context, key string) (int, error) {
 	now := time.Now()
 	windowKey := fmt.Sprintf("rate_limit:%s:%d", key, now.Unix()/60)
 
-	// Get current count
-	countStr, err := r.redisService.Get(ctx, windowKey)
-	currentCount := 0
-	if err == nil {
-		if count, parseErr := strconv.Atoi(countStr); parseErr == nil {
-			currentCount = count
+	newCount, err := r.redisService.Incr(ctx, windowKey)
+	if err != nil {
+		return 0, err
+	}
+
+	if newCount == 1 {
+		// Primeira request do window → seta TTL de 2 min (cobre o minuto + a borda).
+		if expErr := r.redisService.Expire(ctx, windowKey, 2*time.Minute); expErr != nil {
+			r.logger.WithError(expErr).WithField("window_key", windowKey).Warn("Failed to set rate limit window TTL")
 		}
 	}
 
-	// Increment count
-	newCount := currentCount + 1
-
-	// Set with 2-minute TTL (to handle edge cases around minute boundaries)
-	return r.redisService.SetValue(ctx, windowKey, strconv.Itoa(newCount), 2*time.Minute)
+	return int(newCount), nil
 }
 
 // GetCurrentUsage returns the current usage for a key

--- a/internal/services/redis_service.go
+++ b/internal/services/redis_service.go
@@ -324,6 +324,36 @@ func (r *RedisService) Delete(ctx context.Context, key string) error {
 	return nil
 }
 
+// Incr atomically increments the integer value of key by 1 and returns the new
+// value (cria a chave com 1 se não existir). Operação ATÔMICA no Redis — usada
+// pelo rate limiter pra evitar o TOCTOU do get+set (#13).
+func (r *RedisService) Incr(ctx context.Context, key string) (int64, error) {
+	r.recordOperation()
+
+	n, err := r.client.Incr(ctx, key).Result()
+	if err != nil {
+		r.recordError()
+		r.logger.WithError(err).WithField("key", key).Error("Failed to INCR key in Redis")
+		return 0, fmt.Errorf("redis incr error: %w", err)
+	}
+
+	return n, nil
+}
+
+// Expire sets a TTL on key. Best-effort: o rate limiter usa chave minuto-scoped,
+// então a expiração é só cleanup — a CORREÇÃO da contagem vem do INCR atômico (#13).
+func (r *RedisService) Expire(ctx context.Context, key string, ttl time.Duration) error {
+	r.recordOperation()
+
+	if err := r.client.Expire(ctx, key, ttl).Err(); err != nil {
+		r.recordError()
+		r.logger.WithError(err).WithField("key", key).Error("Failed to set TTL on key in Redis")
+		return fmt.Errorf("redis expire error: %w", err)
+	}
+
+	return nil
+}
+
 // Exists checks if a key exists
 func (r *RedisService) Exists(ctx context.Context, key string) (bool, error) {
 	result := r.client.Exists(ctx, key)


### PR DESCRIPTION
## #13 — data races + rate limiter não-atômico
Corrige 3 races (pegos por `go test -race`):

1. **`publishRetryMessage`**: lia `c.rabbitMQ.channel` **sem lock** enquanto o reconnect o substitui sob `Lock`. Fix: publish sob `RLock` + check `isConnected` (mesmo padrão das `PublishMessage`).
2. **`isConnected`/`isShutdown`**: lidos no `handleReconnect`/`reconnect` e escritos no `Close` **sem sincronização**. Não dá pra lockar o loop (`reconnect()` pega o Lock → deadlock). Fix: `bool` → **`atomic.Bool`**.
3. **rate limiter TOCTOU**: `Allow` fazia `get→check→set` não-atômico → sob concorrência liam a mesma contagem e passavam **acima do limite**. Fix: **INCR atômico** (`RedisService.Incr`); `newCount` já inclui a request, `allowed = newCount <= limit`. +`Expire` na 1ª request. `getCurrentCount` (get→set, agora unused) removido.

`RedisService` ganhou `Incr`/`Expire` atômicos + na `RedisServiceInterface`.

## Validação
`go build` + `go vet` + **`go test -race ./...`** limpos. **codex limpo** (1ª iteração).

🤖 Generated with [Claude Code](https://claude.com/claude-code)