### PR TITLE
feat(inbound): aceita message_type=document no webhook

### DIFF
--- a/internal/models/message.go
+++ b/internal/models/message.go
@@ -16,6 +16,7 @@ var KnownMessageTypesList = []string{
 	"audio",
 	"image",
 	"video",
+	"document",
 	"location",
 	"interactive",
 	"unsupported",

--- a/internal/models/message_test.go
+++ b/internal/models/message_test.go
@@ -17,8 +17,9 @@ func TestIsKnownMessageType(t *testing.T) {
 		{name: "interactive", messageType: "interactive", want: true},
 		{name: "unsupported sentinel", messageType: "unsupported", want: true},
 		{name: "unknown sentinel", messageType: "unknown", want: true},
+		{name: "document", messageType: "document", want: true},
 		{name: "typo", messageType: "imgae", want: false},
-		{name: "outbound-only registry type", messageType: "document", want: false},
+		{name: "outbound-only registry type", messageType: "sticker", want: false},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Documento (PDF/TXT/CSV) anexado no WhatsApp vira tipo inbound válido no contrato do gateway. A UM anexa como ContentVersion; o pipeline (SF → Mule → gateway → engine/MCP) lê via Gemini. Sem isso o gateway rejeitava `message_type=document` com 400. Teste do contrato atualizado (sticker cobre o outbound-only).

Parte do rollout de recebimento de documento inbound (SF + gateway + MCP + engine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)