### PR TITLE
fix(engine): retry de 429 + timeout end-to-end no gateway (#R1/#R4)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -84,7 +84,9 @@ GOOGLE_API_MAX_BACKOFF_SECONDS=300
 GOOGLE_API_MIN_BACKOFF_SECONDS=1
 
 # Google Agent Engine Timeouts
-GOOGLE_AGENT_ENGINE_REQUEST_TIMEOUT=1800s
+# #R4: deadline end-to-end do turno (kick-off + retries + poll). 120s cobre o pior
+# turno legítimo e mata o hang (era 1800s = 30 min segurando a goroutine).
+GOOGLE_AGENT_ENGINE_REQUEST_TIMEOUT=120s
 GOOGLE_AGENT_ENGINE_MAX_RETRIES=3
 GOOGLE_AGENT_ENGINE_RETRY_BACKOFF=1s
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -356,8 +356,13 @@ func setDefaults() {
 	viper.SetDefault("GOOGLE_API_MAX_BACKOFF_SECONDS", 300)
 	viper.SetDefault("GOOGLE_API_MIN_BACKOFF_SECONDS", 1)
 
-	// Google Agent Engine (very large timeout for complex reasoning tasks - 30 minutes)
-	viper.SetDefault("GOOGLE_AGENT_ENGINE_REQUEST_TIMEOUT", "1800s")
+	// Google Agent Engine (#R4). Era 1800s (30 min): um engine preso segurava a
+	// goroutine/worker por até 30 min (é o httpClient.Timeout E o deadline do poll).
+	// 120s cobre com folga o pior turno legítimo (~50s: N+1 chamadas de LLM + tools,
+	// com o SGRC já limitado a 20s pelo #R2) e mata o hang. Fica acima do poll de
+	// 110s da casca Mule (o Mule é quem "dá o veredito" de UX no timeout do turno),
+	// e muito abaixo dos 30 min. Tunável no Infisical sem redeploy.
+	viper.SetDefault("GOOGLE_AGENT_ENGINE_REQUEST_TIMEOUT", "120s")
 	viper.SetDefault("GOOGLE_AGENT_ENGINE_MAX_MESSAGE_LENGTH", 32000)
 	viper.SetDefault("GOOGLE_AGENT_ENGINE_MAX_RETRIES", 3)
 	viper.SetDefault("GOOGLE_AGENT_ENGINE_RETRY_BACKOFF", "1s")

--- a/internal/services/google_agent_engine_retry_test.go
+++ b/internal/services/google_agent_engine_retry_test.go
@@ -1,0 +1,125 @@
+package services
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/prefeitura-rio/app-eai-agent-gateway/internal/config"
+)
+
+// roundTripFunc adapta uma função a http.RoundTripper pra interceptar o Do do
+// httpClient sem servidor real (#R1).
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+// noopRateLimiter: os retries chamam s.rateLimiter.Wait — no teste é no-op.
+type noopRateLimiter struct{}
+
+func (noopRateLimiter) Allow(_ context.Context, _ string) (bool, error) { return true, nil }
+func (noopRateLimiter) Wait(_ context.Context, _ string) error          { return nil }
+
+func mkResp(r *http.Request, status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     make(http.Header),
+		Request:    r,
+	}
+}
+
+func newRetryTestService(rt http.RoundTripper) *GoogleAgentEngineService {
+	lg := logrus.New()
+	lg.SetOutput(io.Discard)
+	return &GoogleAgentEngineService{
+		config: &config.Config{
+			GoogleAgentEngine: config.GoogleAgentEngineConfig{
+				Location:     "us-central1",
+				ProjectID:    "proj",
+				MaxRetries:   3,
+				RetryBackoff: time.Millisecond, // backoff ~instantâneo no teste
+			},
+		},
+		logger:      lg,
+		rateLimiter: noopRateLimiter{},
+		httpClient:  &http.Client{Transport: rt},
+	}
+}
+
+func TestPostQueryWithRetry_RetriesTransientThenSucceeds(t *testing.T) {
+	calls := 0
+	svc := newRetryTestService(roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		calls++
+		if calls == 1 {
+			return mkResp(r, 429, "rate limit"), nil // transitório → retenta
+		}
+		return mkResp(r, 200, `{"name":"op-1"}`), nil
+	}))
+
+	out, err := svc.postQueryWithRetry(context.Background(), "tok", map[string]interface{}{}, "eng")
+	if err != nil {
+		t.Fatalf("esperava sucesso após retry, veio erro: %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("esperava 2 chamadas (1 falha + 1 sucesso), veio %d", calls)
+	}
+	if out["name"] != "op-1" {
+		t.Fatalf("resposta inesperada: %v", out)
+	}
+}
+
+func TestPostQueryWithRetry_DoesNotRetryNonTransient(t *testing.T) {
+	calls := 0
+	svc := newRetryTestService(roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		calls++
+		return mkResp(r, 400, "bad request"), nil // 4xx não-transitório → sem retry
+	}))
+
+	_, err := svc.postQueryWithRetry(context.Background(), "tok", map[string]interface{}{}, "eng")
+	if err == nil {
+		t.Fatal("esperava erro (400 não é retryable)")
+	}
+	if calls != 1 {
+		t.Fatalf("esperava 1 chamada (sem retry), veio %d", calls)
+	}
+}
+
+func TestPostQueryWithRetry_DoesNotRetryAmbiguousUnavailable(t *testing.T) {
+	// 502/503/504/500 são AMBÍGUOS (a operação pode ter sido criada) → NÃO
+	// retenta, pra não rodar thread + tools 2× (async_query sem idempotency key).
+	calls := 0
+	svc := newRetryTestService(roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		calls++
+		return mkResp(r, 503, "unavailable"), nil
+	}))
+
+	_, err := svc.postQueryWithRetry(context.Background(), "tok", map[string]interface{}{}, "eng")
+	if err == nil {
+		t.Fatal("esperava erro (503 é ambíguo, não retryable)")
+	}
+	if calls != 1 {
+		t.Fatalf("esperava 1 chamada (503 não retenta), veio %d", calls)
+	}
+}
+
+func TestPostQueryWithRetry_StopsAtMaxRetries(t *testing.T) {
+	calls := 0
+	svc := newRetryTestService(roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		calls++
+		return mkResp(r, 429, "rate limit"), nil // ratelimited sempre → retenta até o teto
+	}))
+
+	_, err := svc.postQueryWithRetry(context.Background(), "tok", map[string]interface{}{}, "eng")
+	if err == nil {
+		t.Fatal("esperava erro após esgotar os retries")
+	}
+	if calls != 4 { // 1 inicial + 3 retries (MaxRetries=3)
+		t.Fatalf("esperava 4 chamadas (1+3), veio %d", calls)
+	}
+}

--- a/internal/services/google_agent_engine_service.go
+++ b/internal/services/google_agent_engine_service.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -127,6 +128,13 @@ type RedisServiceInterface interface {
 // createTokenSourceFromCredentials creates a token source directly from credentials JSON
 // This avoids writing to temp files which may fail in read-only Kubernetes environments
 func createTokenSourceFromCredentials(ctx context.Context, credentialsJSON []byte) (oauth2.TokenSource, error) {
+	// Bounda o HTTP dos refreshes de token (#R4): o oauth2.TokenSource é
+	// context-free no Token(), e sem timeout um token endpoint travado seguraria o
+	// refresh (e o worker) INDEFINIDAMENTE — além dos 120s do request. O oauth2 lê
+	// oauth2.HTTPClient do ctx pros refreshes, então injetamos um client com
+	// timeout aqui; o TokenSource resultante o reusa em toda renovação.
+	ctx = context.WithValue(ctx, oauth2.HTTPClient, &http.Client{Timeout: 30 * time.Second})
+
 	// Create credentials directly from JSON without temp files
 	creds, err := google.CredentialsFromJSON(ctx, credentialsJSON, "https://www.googleapis.com/auth/cloud-platform")
 	if err != nil {
@@ -384,6 +392,10 @@ func (s *GoogleAgentEngineService) getAccessToken(ctx context.Context) (string, 
 		}
 	}
 
+	// O refresh do token é bounded na construção do TokenSource (#R4:
+	// createTokenSourceFromCredentials injeta um http.Client com timeout via
+	// oauth2.HTTPClient), então Token() não fica preso indefinidamente e o worker
+	// não estoura o orçamento do request num token endpoint travado.
 	tok, err := ts.Token()
 	if err != nil {
 		return "", fmt.Errorf("failed to get token: %w", err)
@@ -431,7 +443,7 @@ func (s *GoogleAgentEngineService) postQuery(ctx context.Context, accessToken st
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("non-2xx response: %d - %s", resp.StatusCode, string(bodyBytes))
+		return nil, &engineHTTPError{status: resp.StatusCode, body: string(bodyBytes)}
 	}
 
 	var out map[string]interface{}
@@ -440,6 +452,94 @@ func (s *GoogleAgentEngineService) postQuery(ctx context.Context, accessToken st
 	}
 
 	return out, nil
+}
+
+// engineHTTPError carrega o STATUS HTTP real do kick-off do async_query. Necessário
+// pra o retry (#R1) decidir por status, não por texto: classifyEngineError marca
+// um 5xx com "quota"/"RESOURCE_EXHAUSTED" no body como "ratelimited", mas um 5xx é
+// AMBÍGUO (a operação pode já ter sido criada). Só um 429 GENUÍNO é pré-execução
+// seguro. O Error() mantém o mesmo formato de antes, então classifyEngineError
+// (usado pra escolher a mensagem graciosa) segue funcionando no texto.
+type engineHTTPError struct {
+	status int
+	body   string
+}
+
+func (e *engineHTTPError) Error() string {
+	return fmt.Sprintf("non-2xx response: %d - %s", e.status, e.body)
+}
+
+// postQueryWithRetry envolve postQuery com retry/backoff (#R1) no ÚNICO caso
+// seguramente PRÉ-execução do kick-off do async_query: um HTTP 429 GENUÍNO (a
+// Vertex rejeitou por quota ANTES de criar a operação). Usa MaxRetries/RetryBackoff
+// da config, que existiam porém estavam MORTOS (um único Do → um 429 virava
+// "aguarde" na hora, apesar do gateway logo re-despachar o turno inteiro).
+//
+// A decisão é pelo STATUS (engineHTTPError.status == 429), não pelo texto do erro:
+// classifyEngineError marcaria um 5xx com "quota"/"RESOURCE_EXHAUSTED" no body como
+// "ratelimited", mas um 5xx é AMBÍGUO — a requisição pode ter chegado e criado a
+// operação, que segue rodando enquanto o retry cria OUTRA. Como o async_query não
+// tem idempotency key e só a última operação é pollada, o thread + as tools
+// rodariam 2×. Então 5xx, timeout e erro de conexão NÃO são retentados (ficam pro
+// fallback gracioso / re-despacho externo). Cada retry passa pelo rate limiter.
+func (s *GoogleAgentEngineService) postQueryWithRetry(ctx context.Context, accessToken string, payload map[string]interface{}, reasoningEngineID string) (map[string]interface{}, error) {
+	maxRetries := s.config.GoogleAgentEngine.MaxRetries
+	if maxRetries < 0 {
+		maxRetries = 0
+	}
+	backoff := s.config.GoogleAgentEngine.RetryBackoff
+	if backoff <= 0 {
+		backoff = time.Second
+	}
+
+	var lastErr error
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		// Cada RETRY passa pelo rate limiter da API Google (o Wait de SendMessage
+		// cobre a tentativa 0). Senão uma rajada de retries fura o pacing e agrava
+		// a própria quota que causou o 429.
+		if attempt > 0 {
+			if err := s.rateLimiter.Wait(ctx, "google_agent_engine"); err != nil {
+				return nil, fmt.Errorf("rate limit wait before retry: %w", err)
+			}
+		}
+
+		resp, err := s.postQuery(ctx, accessToken, payload, reasoningEngineID)
+		if err == nil {
+			if attempt > 0 {
+				s.logger.WithField("attempt", attempt+1).Info("async_query kick-off recuperou após retry")
+			}
+			return resp, nil
+		}
+		lastErr = err
+
+		// Retenta SÓ num 429 GENUÍNO (status HTTP, não texto): rejeição por quota
+		// PRÉ-criação da operação. 5xx (mesmo com "quota" no body), timeout e erro
+		// de conexão são ambíguos → não retenta (risco de run duplo).
+		var httpErr *engineHTTPError
+		is429 := errors.As(err, &httpErr) && httpErr.status == http.StatusTooManyRequests
+		if !is429 || attempt >= maxRetries {
+			return nil, err
+		}
+
+		// Backoff exponencial (backoff * 2^attempt), capado em 10s.
+		wait := backoff * time.Duration(1<<uint(attempt))
+		if maxWait := 10 * time.Second; wait > maxWait {
+			wait = maxWait
+		}
+		s.logger.WithFields(logrus.Fields{
+			"attempt":     attempt + 1,
+			"max_retries": maxRetries,
+			"http_status": httpErr.status,
+			"backoff":     wait.String(),
+		}).Warn("429 no kick-off do async_query — retentando")
+
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(wait):
+		}
+	}
+	return nil, lastErr
 }
 
 // pollOperation polls a long-running operation until completion
@@ -489,7 +589,13 @@ func (s *GoogleAgentEngineService) pollOperation(ctx context.Context, accessToke
 			return op, nil
 		}
 
-		time.Sleep(interval)
+		// Espera ciente do ctx (#R4): ao esgotar o deadline único, sai na hora em
+		// vez de dormir o intervalo inteiro antes de o próximo GET falhar.
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(interval):
+		}
 	}
 }
 
@@ -509,6 +615,18 @@ func (s *GoogleAgentEngineService) extractOperationName(resp map[string]interfac
 // queryReasoningEngine makes a request to the reasoning engine with proper async handling
 // messageType is optional - if nil, no type parameter is sent; if "history", updates history without response
 func (s *GoogleAgentEngineService) queryReasoningEngine(ctx context.Context, threadID, message string, reasoningEngineID *string, messageType *string) (string, error) {
+	// #R4/#R1: um ÚNICO deadline end-to-end (RequestTimeout) — derivado ANTES do
+	// token pra cobrir OAuth + kick-off + seus retries + poll. Sem isso, o
+	// httpClient.Timeout (por Do) e o deadline próprio do poll eram INDEPENDENTES
+	// → 4 tentativas × 120s + 120s de poll somavam minutos apesar do "120s", e o
+	// getAccessToken ficava fora do orçamento. O poll recebe só o budget RESTANTE.
+	requestDeadline := time.Now().Add(s.config.GoogleAgentEngine.RequestTimeout)
+	if s.config.GoogleAgentEngine.RequestTimeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithDeadline(ctx, requestDeadline)
+		defer cancel()
+	}
+
 	accessToken, err := s.getAccessToken(ctx)
 	if err != nil {
 		return "", fmt.Errorf("failed to get access token: %w", err)
@@ -561,7 +679,7 @@ func (s *GoogleAgentEngineService) queryReasoningEngine(ctx context.Context, thr
 		"reasoning_engine_id":  engineID,
 	}).Debug("Making async_query call to reasoning engine")
 
-	resp, err := s.postQuery(ctx, accessToken, payload, engineID)
+	resp, err := s.postQueryWithRetry(ctx, accessToken, payload, engineID)
 	if err != nil {
 		return "", fmt.Errorf("failed to post query: %w", err)
 	}
@@ -580,8 +698,14 @@ func (s *GoogleAgentEngineService) queryReasoningEngine(ctx context.Context, thr
 
 	s.logger.WithField("operation_name", opName).Debug("Polling operation until completion")
 
-	// Poll with reasonable intervals using configured timeout
-	op, err := s.pollOperation(ctx, accessToken, opName, 2*time.Second, s.config.GoogleAgentEngine.RequestTimeout)
+	// Poll com o budget RESTANTE do deadline único (#R4) — o kick-off + retros já
+	// consumiram parte dele. Sem RequestTimeout configurado (<=0), mantém o valor
+	// bruto pra não zerar o budget.
+	pollBudget := s.config.GoogleAgentEngine.RequestTimeout
+	if s.config.GoogleAgentEngine.RequestTimeout > 0 {
+		pollBudget = time.Until(requestDeadline)
+	}
+	op, err := s.pollOperation(ctx, accessToken, opName, 2*time.Second, pollBudget)
 	if err != nil {
 		return "", fmt.Errorf("failed to poll operation: %w", err)
 	}
@@ -925,6 +1049,14 @@ func (s *GoogleAgentEngineService) gracefulMessageForClass(class string) string 
 func (s *GoogleAgentEngineService) SendHistoryUpdate(ctx context.Context, threadID string, messages []models.HistoryMessage, reasoningEngineID *string) (map[string]interface{}, error) {
 	start := time.Now()
 
+	// #R4/#R1: mesmo deadline único end-to-end do fluxo de resposta — o history
+	// update também é um async_query e sem isso ficava exposto ao timeout de 30 min.
+	if s.config.GoogleAgentEngine.RequestTimeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, s.config.GoogleAgentEngine.RequestTimeout)
+		defer cancel()
+	}
+
 	s.logger.WithFields(logrus.Fields{
 		"thread_id":        threadID,
 		"messages_count":   len(messages),
@@ -998,7 +1130,7 @@ func (s *GoogleAgentEngineService) SendHistoryUpdate(ctx context.Context, thread
 		"reasoning_engine_id": engineID,
 	}).Debug("Making async_query call with type=history to reasoning engine")
 
-	resp, err := s.postQuery(ctx, accessToken, payload, engineID)
+	resp, err := s.postQueryWithRetry(ctx, accessToken, payload, engineID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to post query: %w", err)
 	}


### PR DESCRIPTION
## Por que

Duas guardas de resiliência que **existiam na config porém estavam mortas ou inseguras**, e são causa-raiz do turno não fechar sob quota/lentidão da Vertex (parte do Tier-0 de confiabilidade — estudo de melhorias da casca).

## O que muda

**R1 — retry do kick-off do async_query.** `GOOGLE_AGENT_ENGINE_MAX_RETRIES/RETRY_BACKOFF` existiam mas **nunca eram usados** (um único `Do` → um 429 virava "aguarde" na hora). Agora `postQueryWithRetry` retenta **só num 429 GENUÍNO** — decidido pelo **status HTTP** (`engineHTTPError`), não pelo texto (`classifyEngineError` marcaria um 5xx-com-quota como `ratelimited`). **5xx, timeout e conexão são ambíguos** (a operação pode já ter sido criada, e o async_query não tem idempotency key → **run duplo**) e não são retentados. Cada retry passa pelo rate limiter.

**R4 — `REQUEST_TIMEOUT` 1800s (30 min) → 120s**, agora um **deadline único end-to-end** (`context.WithDeadline` antes do `getAccessToken`) cobrindo OAuth + kick-off + retries + poll (o poll recebe o budget restante). Refresh de token **bounded na construção** (`oauth2.HTTPClient` timeout 30s). Ambos os caminhos de async_query cobertos (`queryReasoningEngine` + `SendHistoryUpdate`).

## Follow-up conhecido (pré-existente, não-regressão)

Sob **outage do token endpoint do Google** com workers concorrentes, o `oauth2.ReuseTokenSource` serializa refreshes sob mutex → pior caso pode passar de 120s. Esta mudança **melhora** o caso (30s/refresh vs. ilimitado antes); o fix completo (refresher context-aware single-flight) fica como follow-up. Revisado em 7 rodadas de `codex review`.

## R3 (fora deste PR)

Ligar `GOOGLE_API_RATE_LIMIT_ENABLED` em código estrangularia prod (default 60 req/min = 1/s). **Recomendação: env-flip no Infisical** (`=true`) + tunar `GOOGLE_API_MAX_REQUESTS_PER_MINUTE` à quota da Vertex + monitorar.

## Testes

4 casos de `postQueryWithRetry` (retry 429, não-retry 4xx, não-retry 5xx ambíguo, para no teto) via `RoundTripper` mock. `build`/`vet`/`gofmt`/suite OK. Deploy via infra (ArgoCD); `REQUEST_TIMEOUT` tunável no Infisical sem redeploy.