### PR TITLE
fix: use exclusive lock in RabbitMQ HealthCheck to prevent channel race (prod)

### DIFF
--- a/internal/services/rabbitmq_service.go
+++ b/internal/services/rabbitmq_service.go
@@ -497,9 +497,17 @@ func (r *RabbitMQService) reconnect() {
 }
 
 // HealthCheck implements the HealthChecker interface
+//
+// This uses an exclusive Lock (not RLock) because it performs channel-mutating
+// operations (QueueDeclare/QueueDelete) on the same shared *amqp.Channel used
+// by PublishMessage*/ConsumeQueue. The amqp091-go client does not support
+// concurrent use of a single channel by multiple goroutines: if this ran
+// under RLock (as it did previously), a health check could interleave AMQP
+// frames with a concurrent publish and get a fast, spurious failure - this is
+// the confirmed root cause of intermittent /ready 503s (INFRAVPIA-233).
 func (r *RabbitMQService) HealthCheck(ctx context.Context) error {
-	r.mutex.RLock()
-	defer r.mutex.RUnlock()
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
 
 	if !r.isConnected || r.connection == nil || r.connection.IsClosed() {
 		return fmt.Errorf("RabbitMQ connection is not available")


### PR DESCRIPTION
Cherry-pick of #59 (already merged + validated in `staging` for ~1h with zero regressions) directly onto `main`, deliberately **not** a wholesale staging→main promotion.

`staging` is currently 43 commits ahead of `main` (oldest from May 11 — Gov.br OAuth2/PKCE auth flow, inbound media handling, WhatsApp error-UX changes, etc.). Those are a separate, much larger promotion decision and out of scope here — this PR carries **only** the RabbitMQ health-check fix.

## Problem / fix

See #59 for full detail. Summary: `RabbitMQService.HealthCheck()` ran channel-mutating ops under `RLock`, racing with `PublishMessage*`/`ConsumeQueue` on the same shared `*amqp.Channel` (not safe for concurrent goroutine use in amqp091-go). Root cause of the intermittent `/ready` 503s tripping the Gatus/Discord alert on `eai-agent-gateway` prod. Fix: `Lock`/`Unlock` instead, matching `connect()`/`reconnect()`/`Close()`.

## Validation so far

- `go build/vet/test ./...` + `go test -race ./internal/services/...` — all pass (re-verified against current `main` base too)
- Deployed to staging ~1h ago: clean rollout, 0 pod restarts, 0 `/ready` non-200s, 0 RabbitMQ errors in logs, Gatus green across every check cycle since

Full investigation + staging validation trail: [INFRAVPIA-233](https://iplanrio-pcrj.atlassian.net/browse/INFRAVPIA-233)